### PR TITLE
replace tidal.el url

### DIFF
--- a/doc/install-linux.sh
+++ b/doc/install-linux.sh
@@ -17,7 +17,7 @@ cabal update
 cabal install tidal
 
 mkdir ~/tidal/emacs
-wget -O ~/tidal/emacs/tidal.el https://raw.github.com/yaxu/Tidal/master/tidal.el
+wget -O ~/tidal/emacs/tidal.el https://raw.githubusercontent.com/yaxu/Tidal/master/tidal.el
 touch ~/.emacs
 echo "(add-to-list 'load-path \"~/tidal/emacs\")" >> ~/.emacs
 echo "(require 'tidal)" >> ~/.emacs


### PR DESCRIPTION
should fix recurring problems with empty tidal.el for new users (as previous url would redirect and result in an empty file)
