### PR TITLE
Fix typo in tidal.md

### DIFF
--- a/doc/tidal.md
+++ b/doc/tidal.md
@@ -763,7 +763,7 @@ playing all of the patterns in the list simultaneously.
 ~~~~ {.haskell}
 d1 $ stack [ 
   sound "bd bd*2", 
-  sound "hh*s [sn cp] cp future*4", 
+  sound "hh*2 [sn cp] cp future*4", 
   sound (samples "arpy*8", (run 16))
 ]
 ~~~~
@@ -774,7 +774,7 @@ stack:
 ~~~~ {.haskell}
 d1 $ whenmod 5 3 (striate 3) $ stack [ 
   sound "bd bd*2", 
-  sound "hh*s [sn cp] cp future*4", 
+  sound "hh*2 [sn cp] cp future*4", 
   sound (samples "arpy*8", (run 16))
 ] |+| speed "[[1 0.8], [1.5 2]*2]/3"
 ~~~~


### PR DESCRIPTION
I'm guessing these are supposed to be *2 rather than *s
