### PR TITLE
Added effects and filters

### DIFF
--- a/Sound/Tidal/Dirt.hs
+++ b/Sound/Tidal/Dirt.hs
@@ -37,7 +37,13 @@ dirt = OscShape {path = "/play",
                             I "cut" (Just (0)),
                             F "delay" (Just (0)),
                             F "delaytime" (Just (-1)),
-                            F "delayfeedback" (Just (-1))
+                            F "delayfeedback" (Just (-1)),
+                            F "crush" (Just 0),
+                            I "coarse" (Just 0),
+                            F "hcutoff" (Just 0),
+                            F "hresonance" (Just 0),
+                            F "bandf" (Just 0),
+                            F "bandq" (Just 0)
                           ],
                  timestamp = True
                 }
@@ -114,6 +120,14 @@ gain         = makeF dirt "gain"
 delay        = makeF dirt "delay"
 delaytime    = makeF dirt "delaytime"
 delayfeedback = makeF dirt "delayfeedback"
+crush        = makeF dirt "crush"
+
+coarse :: Pattern Int -> OscPattern
+coarse       = makeI dirt "coarse"
+hcutoff      = makeF dirt "hcutoff"
+hresonance   = makeF dirt "hresonance"
+bandf        = makeF dirt "bandf"
+bandq        = makeF dirt "bandq"
 
 
 cut :: Pattern Int -> OscPattern


### PR DESCRIPTION
These _require_ the new version of Dirt, see the pull request there for the source on how they work.  In summary, there are new parameters: crush, coarse, hcutoff, hresonance, bandf, bandq.

Crush simulates quantization to a specified bit depth, coarse simulates resampling by every Nth sample, and the other parameters are for highpass and bandpass filters.
