### PR TITLE
New Dirt params and some shortcut functions

### DIFF
--- a/Sound/Tidal/Dirt.hs
+++ b/Sound/Tidal/Dirt.hs
@@ -43,7 +43,9 @@ dirt = OscShape {path = "/play",
                             F "hcutoff" (Just 0),
                             F "hresonance" (Just 0),
                             F "bandf" (Just 0),
-                            F "bandq" (Just 0)
+                            F "bandq" (Just 0),
+                            F "stretchTo" (Just 0),
+                            F "matchcps" (Just 0)
                           ],
                  timestamp = MessageStamp,
                  latency = 0.04,
@@ -134,6 +136,8 @@ hresonance   = makeF dirt "hresonance"
 bandf        = makeF dirt "bandf"
 bandq        = makeF dirt "bandq"
 
+stretchTo    = makeF dirt "stretchTo"
+matchcps     = makeF dirt "matchcps"
 
 cut :: Pattern Int -> OscPattern
 cut = makeI dirt "cut"
@@ -161,3 +165,9 @@ striateO p n o = cat $ map (\x -> off (fromIntegral x) p) [0 .. n-1]
   where off i p = p |+| begin ((atom $ (fromIntegral i / fromIntegral n) + o) :: Pattern Double) |+| end ((atom $ (fromIntegral (i+1) / fromIntegral n) + o) :: Pattern Double)
 
 metronome = slow 2 $ sound (p "[odx, [hh]*8]")
+
+pitch = speed . ((step **) <$> )
+  where step = (2.0 ** (1.0/12.0))
+
+combp x = delay "1" |+| delayfeedback "0" |+| delaytime (fmap recip x)
+combm x = delay "-1" |+| delayfeedback "0" |+| delaytime (fmap recip x)


### PR DESCRIPTION
Added “stretchTo” and “matchcps” parameters to dirt, to help stretch or
beatmatch samples when playing them back.  This update also requires
the related update to Dirt.  Both parameters override the “speed” and
“accelerate” parameters, and instruct Dirt to stretch the sample to
fill the specified time in seconds (for stretchTo) or to match the
specified cycles/second (for matchcps). So something like

cps 1.5
d1 $ sound "breaks125/2" |+| matchcps (pure $ 1.5/2)

will match the “breaks125” sample to the loop tempo.  Note that this
does require the sample itself to begin and end at suitable loop points.

I’ve also added a helper function that I learned about from David
Ogborn on a thread at lurk.org:

pitch = speed . ((step **) <$> )
  where step = (2.0 ** (1.0/12.0))

So you can easily adjust sample playback speed by amounts corresponding
to semitones.

Finally, I added functions “combp” and “combm” that simplify using the
“delay” parameter to implement comb filters.  “combp” is a positive
(low-pass) filter, “combm” is a negative (high-pass) filter.  They take
the frequency as an argument:

d1 $ sound “breaks125/2” |+| combp “6000”

I've also added some functionality to the bandpass filter, "coarse", and "crush". Using a negative frequency with "bandf" will switch the filter to a bandnotch, and using negative numbers with "coarse" and "crush" will use different quantization methods for each of those.

This Tidal update requires the corresponding Dirt update - using it with the old Dirt will generate errors.