### PR TITLE
replaced all the |+| with |*|

### DIFF
--- a/Sound/Tidal/Dirt.hs
+++ b/Sound/Tidal/Dirt.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE NoMonomorphismRestriction #-}
-  
+
 module Sound.Tidal.Dirt where
 
 import Sound.OSC.FD (Datum)
@@ -116,7 +116,7 @@ visualcallback = do t <- ticker
 
 --dirtyvisualstream name = do cb <- visualcallback
 --                            streamcallback cb "127.0.0.1" "127.0.0.1" name "127.0.0.1" 7771 dirt
-                            
+
 
 sound        = makeS dirt "sound"
 offset       = makeF dirt "offset"
@@ -157,22 +157,22 @@ pick name n = name ++ ":" ++ (show n)
 
 striate :: Int -> OscPattern -> OscPattern
 striate n p = cat $ map (\x -> off (fromIntegral x) p) [0 .. n-1]
-  where off i p = p 
-                  |+| begin (atom (fromIntegral i / fromIntegral n)) 
-                  |+| end (atom (fromIntegral (i+1) / fromIntegral n))
+  where off i p = p
+                  |*| begin (atom (fromIntegral i / fromIntegral n))
+                  |*| end (atom (fromIntegral (i+1) / fromIntegral n))
 
 striate' :: Int -> Double -> OscPattern -> OscPattern
 striate' n f p = cat $ map (\x -> off (fromIntegral x) p) [0 .. n-1]
-  where off i p = p |+| begin (atom (slot * i) :: Pattern Double) |+| end (atom ((slot * i) + f) :: Pattern Double)
+  where off i p = p |*| begin (atom (slot * i) :: Pattern Double) |*| end (atom ((slot * i) + f) :: Pattern Double)
         slot = (1 - f) / (fromIntegral n)
 
 striateO :: OscPattern -> Int -> Double -> OscPattern
 striateO p n o = cat $ map (\x -> off (fromIntegral x) p) [0 .. n-1]
-  where off i p = p |+| begin ((atom $ (fromIntegral i / fromIntegral n) + o) :: Pattern Double) |+| end ((atom $ (fromIntegral (i+1) / fromIntegral n) + o) :: Pattern Double)
+  where off i p = p |*| begin ((atom $ (fromIntegral i / fromIntegral n) + o) :: Pattern Double) |*| end ((atom $ (fromIntegral (i+1) / fromIntegral n) + o) :: Pattern Double)
 
 striateL :: Int -> Int -> OscPattern -> OscPattern
-striateL n l p = striate n p |+| loop (atom $ fromIntegral l)
-striateL' n f l p = striate' n f p |+| loop (atom $ fromIntegral l)
+striateL n l p = striate n p |*| loop (atom $ fromIntegral l)
+striateL' n f l p = striate' n f p |*| loop (atom $ fromIntegral l)
 
 metronome = slow 2 $ sound (p "[odx, [hh]*8]")
 
@@ -197,14 +197,14 @@ xfade :: Time -> [OscPattern] -> OscPattern
 xfade = xfadeIn 2
 
 stut :: Integer -> Double -> Rational -> OscPattern -> OscPattern
-stut steps feedback time p = stack (p:(map (\x -> (((x%steps)*time) ~> (p |+| gain (pure $ scale (fromIntegral x))))) [1..(steps-1)])) 
-  where scale x 
+stut steps feedback time p = stack (p:(map (\x -> (((x%steps)*time) ~> (p |*| gain (pure $ scale (fromIntegral x))))) [1..(steps-1)]))
+  where scale x
           = ((+feedback) . (*(1-feedback)) . (/(fromIntegral steps)) . ((fromIntegral steps)-)) x
 
 histpan :: Int -> Time -> [OscPattern] -> OscPattern
 histpan _ _ [] = silence
 histpan 0 _ _ = silence
-histpan n _ ps = stack $ map (\(i,p) -> p |+| pan (atom $ (fromIntegral i) / (fromIntegral n'))) (enumerate ps')
+histpan n _ ps = stack $ map (\(i,p) -> p |*| pan (atom $ (fromIntegral i) / (fromIntegral n'))) (enumerate ps')
   where ps' = take n ps
         n' = length ps' -- in case there's fewer patterns than requested
 
@@ -218,4 +218,3 @@ anticipateIn t now = wash (spread' (stut 8 0.2) (now ~> (slow t $ (toRational . 
 
 anticipate :: Time -> [OscPattern] -> OscPattern
 anticipate = anticipateIn 8
-

--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -72,7 +72,7 @@ instance Monad Pattern where
   return = pure
   -- Pattern a -> (a -> Pattern b) -> Pattern b
   -- Pattern Char -> (Char -> Pattern String) -> Pattern String
-  
+
   p >>= f = -- unwrap (f <$> p)
     Pattern (\a -> concatMap
                    (\((s,e), (s',e'), x) -> map (\ev -> ((s,e), (s',e'), thd' ev)) $
@@ -560,7 +560,7 @@ Examples:
 d1 $ sound $ preplace (1,1) "x [~ x] x x" "bd sn"
 d1 $ sound $ preplace (1,1) "x(3,8)" "bd sn"
 d1 $ sound $ "x(3,8)" <~> "bd sn"
-d1 $ sound "[jvbass jvbass:5]*3" |+| (shape $ "1 1 1 1 1" <~> "0.2 0.9")
+d1 $ sound "[jvbass jvbass:5]*3" |*| (shape $ "1 1 1 1 1" <~> "0.2 0.9")
 @
 
 It is assumed the pattern fits into a single cycle. This works well with

--- a/Sound/Tidal/Strategies.hs
+++ b/Sound/Tidal/Strategies.hs
@@ -21,13 +21,13 @@ triple = stutter 3
 quad   = stutter 4
 double = echo
 
-jux f p = stack [p |+| pan (pure 0), f $ p |+| pan (pure 1)]
-juxcut f p = stack [p     |+| pan (pure 0) |+| cut (pure (-1)), 
-                    f $ p |+| pan (pure 1) |+| cut (pure (-2))
+jux f p = stack [p |*| pan (pure 0), f $ p |*| pan (pure 1)]
+juxcut f p = stack [p     |*| pan (pure 0) |*| cut (pure (-1)),
+                    f $ p |*| pan (pure 1) |*| cut (pure (-2))
                    ]
-jux4 f p = stack [p |+| pan (pure 0), f $ p |+| pan (pure 2)]
+jux4 f p = stack [p |*| pan (pure 0), f $ p |*| pan (pure 2)]
 
-juxBy n f p = stack [p |+| pan (pure $ 0.5 - (n/2)), f $ p |+| pan (pure $ 0.5 + (n/2))]
+juxBy n f p = stack [p |*| pan (pure $ 0.5 - (n/2)), f $ p |*| pan (pure $ 0.5 + (n/2))]
 
 -- every 4 (smash 4 [1, 2, 3]) $ sound "[odx sn/2 [~ odx] sn/3, [~ hh]*4]"
 
@@ -48,7 +48,7 @@ samples' p p' = (flip pick) <$> p' <*> p
 {-
 scrumple :: Time -> Pattern a -> Pattern a -> Pattern a
 scrumple o p p' = p'' -- overlay p (o ~> p'')
-  where p'' = Pattern $ \a -> concatMap 
+  where p'' = Pattern $ \a -> concatMap
                               (\((s,d), vs) -> map (\x -> ((s,d),
                                                            snd x
                                                           )
@@ -58,8 +58,8 @@ scrumple o p p' = p'' -- overlay p (o ~> p'')
 -}
 
 --rev :: Pattern a -> Pattern a
---rev p = Pattern $ \a -> concatMap 
---                        (\a' -> mapFsts mirrorArc $ 
+--rev p = Pattern $ \a -> concatMap
+--                        (\a' -> mapFsts mirrorArc $
 --                                (arc p (mirrorArc a')))
 --                        (arcCycles a)
 
@@ -70,7 +70,7 @@ spin :: Int -> OscPattern -> OscPattern
 spin copies p =
   stack $ map (\n -> let offset = toInteger n % toInteger copies in
                      offset <~ p
-                     |+| pan (pure $ fromRational offset)
+                     |*| pan (pure $ fromRational offset)
               )
           [0 .. (copies - 1)]
 
@@ -86,7 +86,7 @@ sinewave4 = ((*4) <$> sinewave1)
 rand4 = ((*4) <$> rand)
 
 stackwith p ps | null ps = silence
-               | otherwise = stack $ map (\(i, p') -> p' |+| (((fromIntegral i) % l) <~ p)) (zip [0 ..] ps)
+               | otherwise = stack $ map (\(i, p') -> p' |*| (((fromIntegral i) % l) <~ p)) (zip [0 ..] ps)
   where l = fromIntegral $ length ps
 
 {-
@@ -121,7 +121,7 @@ chopArc :: Arc -> Int -> [Arc]
 chopArc (s, e) n = map (\i -> ((s + (e-s)*(fromIntegral i/fromIntegral n)), s + (e-s)*((fromIntegral $ i+1)/fromIntegral n))) [0 .. n-1]
 {-
 normEv :: Event a -> Event a -> Event a
-normEv ev@(_, (s,e), _) ev'@(_, (s',e'), _) 
+normEv ev@(_, (s,e), _) ev'@(_, (s',e'), _)
        | not on && not off = [] -- shouldn't happen
        | on && off = splitEv ev'
        | not on && s' > sam s = []
@@ -143,7 +143,7 @@ en :: [(Int, Int)] -> Pattern String -> Pattern String
 en ns p = stack $ map (\(i, (k, n)) -> e k n (samples p (pure i))) $ enumerate ns
 
 weave :: Rational -> OscPattern -> [OscPattern] -> OscPattern
-weave t p ps = weave' t p (map (\x -> (x |+|)) ps)
+weave t p ps = weave' t p (map (\x -> (x |*|)) ps)
 
 weave' :: Rational -> Pattern a -> [Pattern a -> Pattern a] -> Pattern a
 weave' t p fs | l == 0 = silence


### PR DESCRIPTION
is swoped all the |+| with |*|, tested and worked
the only problem is that if you use a function like stut for example in combination with |+| it gives some problems
like this:
d1 $ stut 8 0.5 0.25 $ sound "bd sn {~ bd} sn" |+| gain 0.9

maybe |+| should be removed entirely 