### PR TITLE
update stack resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.stack-work
 .cabal-sandbox
 cabal.sandbox.config
 dist

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,4 +8,4 @@ extra-deps:
 - hosc-0.15
 - multiset-comb-0.2.4
 - permutation-0.5.0.5
-resolver: lts-2.14
+resolver: lts-3.11


### PR DESCRIPTION
the previous version was bound to ghc-7.8.4 this would also update ghc
to 7.10.2

See http://www.stackage.org/lts-3.11