### PR TITLE
Generic Stream Implementation

### DIFF
--- a/Sound/Tidal/Context.hs
+++ b/Sound/Tidal/Context.hs
@@ -18,3 +18,4 @@ import Sound.Tidal.Transition as C
 import Sound.Tidal.MidiStream as C
 import Sound.Tidal.MIDI.Params as C
 import Sound.Tidal.Synth as C
+import Sound.Tidal.SerialStream as C

--- a/Sound/Tidal/Context.hs
+++ b/Sound/Tidal/Context.hs
@@ -15,4 +15,6 @@ import Sound.Tidal.Time as C
 import Sound.Tidal.SuperCollider as C
 import Sound.Tidal.Params as C
 import Sound.Tidal.Transition as C
-
+import Sound.Tidal.MidiStream as C
+import Sound.Tidal.MIDI.Params as C
+import Sound.Tidal.Synth as C

--- a/Sound/Tidal/Dirt.hs
+++ b/Sound/Tidal/Dirt.hs
@@ -63,7 +63,7 @@ dirtSlang = OscSlang {
   preamble = []
   }
 
-superDirtSlang = dirtSlang {timestamp = BundleStamp}
+superDirtSlang = dirtSlang { timestamp = BundleStamp }
 
 superDirtBackend = do
   s <- makeConnection "127.0.0.1" 57120 superDirtSlang
@@ -76,8 +76,6 @@ superDirtState = do
 dirtBackend = do
   s <- makeConnection "127.0.0.1" 7771 dirtSlang
   return $ Backend s
-
-
 
 -- dirtstart name = start "127.0.0.1" 7771 dirt
 
@@ -92,6 +90,11 @@ dirtState = do
 dirtSetters :: IO Time -> IO (ParamPattern -> IO (), (Time -> [ParamPattern] -> ParamPattern) -> ParamPattern -> IO ())
 dirtSetters getNow = do ds <- dirtState
                         return (setter ds, transition getNow ds)
+
+superDirtSetters :: IO Time -> IO (ParamPattern -> IO (), (Time -> [ParamPattern] -> ParamPattern) -> ParamPattern -> IO ())
+superDirtSetters getNow = do ds <- superDirtState
+                             return (setter ds, transition getNow ds)
+
 
 -- -- disused parameter..
 dirtstream _ = dirtStream

--- a/Sound/Tidal/MIDI/Control.hs
+++ b/Sound/Tidal/MIDI/Control.hs
@@ -1,0 +1,59 @@
+module Sound.Tidal.MIDI.Control where
+
+import qualified Sound.Tidal.Stream as S
+
+import Sound.Tidal.Params
+import Sound.Tidal.MIDI.Params
+
+type RangeMapFunc = (Int, Int) -> Double -> Int
+
+data ControlChange = CC { param :: S.Param, midi :: Int, range :: (Int, Int), vdefault :: Double, scalef :: RangeMapFunc }
+           | NRPN { param :: S.Param, midi :: Int, range :: (Int, Int), vdefault :: Double, scalef :: RangeMapFunc }
+           | SysEx { param :: S.Param, midi :: Int, range :: (Int, Int), vdefault :: Double, scalef :: RangeMapFunc }
+
+data ControllerShape = ControllerShape {
+  controls :: [ControlChange],
+  latency :: Double
+  }
+
+
+toShape :: ControllerShape -> S.Shape
+toShape cs =
+  let params = [dur_p, note_p, velocity_p] ++ params'
+      params' = [param p | p <- (controls cs)]
+  in S.Shape {   S.params = params,
+                 S.cpsStamp = False,
+                 S.latency = latency cs
+             }
+
+passThru :: (Int, Int) -> Double -> Int
+passThru (_, _) = floor -- no sanitizing of range…
+
+mapRange :: (Int, Int) -> Double -> Int
+mapRange (low, high) = floor . (+ (fromIntegral low)) . (* ratio)
+  where ratio = fromIntegral $ high - low
+
+mCC :: S.Param -> Int -> ControlChange
+mCC p m = CC {param=p, midi=m, range=(0, 127), vdefault=0, scalef=mapRange }
+
+mNRPN :: S.Param -> Int -> ControlChange
+mNRPN p m = NRPN {param=p, midi=m, range=(0, 127), vdefault=0, scalef=mapRange }
+
+mrNRPN :: S.Param -> Int -> (Int, Int) -> Double -> ControlChange
+mrNRPN p m r d = NRPN {param=p, midi=m, range=r, vdefault=d, scalef=mapRange }
+
+toParams :: ControllerShape -> [S.Param]
+toParams shape = map param (controls shape)
+
+ctrlN :: Num b => ControllerShape -> S.Param -> Maybe b
+ctrlN shape x = fmap fromIntegral $ fmap midi (paramN shape x)
+
+paramN :: ControllerShape -> S.Param -> Maybe ControlChange
+paramN shape x
+  | x `elem` names = paramX $ matching p
+  | otherwise = Nothing -- error $ "No such Controller param: " ++ show x
+  where names = toParams shape
+        paramX [] = Nothing
+        paramX (h:_) = Just h
+        matching = filter ((== x) . param)
+        p = controls shape

--- a/Sound/Tidal/MIDI/Device.hs
+++ b/Sound/Tidal/MIDI/Device.hs
@@ -1,0 +1,36 @@
+module Sound.Tidal.MIDI.Device where
+import qualified Sound.PortMidi as PM
+
+displayOutputDevices :: IO String
+displayOutputDevices = do
+  devices <- getIndexedDevices
+  return $ displayDevices $ getOutputDevices devices
+
+displayDevices :: Show a => [(a, PM.DeviceInfo)] -> String
+displayDevices devices =
+  let indices = map (show . fst) devices
+      names = map ((":\t"++) . PM.name . snd) devices
+      pairs = zipWith (++) indices names
+  in unlines (["ID:\tName"]++pairs)
+
+getOutputDevices :: [(a, PM.DeviceInfo)] -> [(a, PM.DeviceInfo)]
+getOutputDevices = filter (PM.output . snd)
+
+getIndexedDevices :: IO [(Integer, PM.DeviceInfo)]
+getIndexedDevices = do
+  rawDevices <- getDevices
+  return $ zip [0..] rawDevices
+
+getDevices :: IO ([PM.DeviceInfo])
+getDevices = do
+  PM.initialize
+  count <- PM.countDevices
+  mapM PM.getDeviceInfo [0..(count - 1)]
+
+getIDForDeviceName :: Num a => String -> IO (Maybe a)
+getIDForDeviceName name = do
+  odevs <- fmap getOutputDevices getIndexedDevices
+  let res = filter (\n -> (PM.name . snd) n == name) odevs
+  case res of
+    [] -> return Nothing
+    [dev] -> return $ Just $ fromIntegral $ fst dev

--- a/Sound/Tidal/MIDI/Params.hs
+++ b/Sound/Tidal/MIDI/Params.hs
@@ -1,0 +1,25 @@
+module Sound.Tidal.MIDI.Params where
+
+import Sound.Tidal.Pattern
+import Sound.Tidal.Stream
+import Sound.Tidal.Params
+
+dur :: Pattern Double -> ParamPattern
+dur = make' VF dur_p
+dur_p = F "dur" (Just 0.05)
+
+note :: Pattern Int -> ParamPattern
+note = make' VI note_p
+note_p = I "note" Nothing
+
+modwheel :: Pattern Double -> ParamPattern
+modwheel = make' VF modwheel_p
+modwheel_p = F "modwheel" (Just 0)
+
+expression :: Pattern Double -> ParamPattern
+expression = make' VF expression_p
+expression_p = F "expression" (Just 1)
+
+sustainpedal :: Pattern Double -> ParamPattern
+sustainpedal = make' VF sustainpedal_p
+sustainpedal_p = F "sustainpedal_p" (Just 0)

--- a/Sound/Tidal/MidiStream.hs
+++ b/Sound/Tidal/MidiStream.hs
@@ -1,0 +1,239 @@
+module Sound.Tidal.MidiStream (midiStream, midiBackend, midiState, midiSetters) where
+
+-- generics
+import qualified Data.Map as Map
+import Data.List (sortBy)
+import Data.Maybe
+import Data.Ord (comparing)
+import Data.Time (getCurrentTime, UTCTime, diffUTCTime)
+import Data.Time.Clock.POSIX
+import Control.Concurrent
+import Control.Concurrent.MVar
+import Data.Bits
+import Foreign.C
+
+-- Tidal specific
+import Sound.Tidal.Tempo (Tempo, cps)
+import Sound.Tidal.Stream as S
+import Sound.Tidal.Utils
+import Sound.Tidal.Time
+import Sound.Tidal.Transition (transition)
+
+-- MIDI specific
+import Sound.Tidal.MIDI.Device
+import Sound.Tidal.MIDI.Control
+import Sound.Tidal.MIDI.Params
+import qualified Sound.PortMidi as PM
+
+
+data Output = Output {
+                       conn :: PM.PMStream,
+                       lock :: MVar (),
+                       offset :: Double,
+                       buffer :: MVar [PM.PMEvent]
+                     }
+
+type MidiMap = Map.Map S.Param (Maybe Int)
+
+toMidiEvent :: ControllerShape -> S.Param -> Value -> Maybe Int
+toMidiEvent s p (VF x) = ($) <$> mscale <*> mrange <*> pure x
+    where
+      mrange = fmap range mcc
+      mscale = fmap scalef mcc
+      mcc = paramN s p
+toMidiEvent s p (VI x) = Just x
+toMidiEvent s p (VS x) = Nothing -- ignore strings for now, we might 'read' them later
+
+toMidiMap :: ControllerShape -> S.ParamMap -> MidiMap
+toMidiMap s m = Map.mapWithKey (toMidiEvent s) (Map.mapMaybe (id) m)
+
+
+send s ch cshape shape change tick o ctrls (tdur:tnote:trest) = midi
+    where
+      midi = sendmidi s cshape ch' (note, vel, dur) (diff) ctrls
+      diff = floor $ (*1000) $ (logicalOnset - (offset s))
+      note = fromIntegral $ ivalue $ snd tnote
+      dur = realToFrac $ fvalue $ snd tdur
+      (vel, nudge) = case length trest of
+        2 -> (mkMidi $ trest !! 1, fvalue $ snd $ trest !! 0)
+        1 -> (mkMidi $ trest !! 0, 0)
+      ch' = fromIntegral ch
+      mkMidi = fromIntegral . floor . (*127) . fvalue . snd
+      logicalOnset = logicalOnset' change tick o nudge
+
+makeConnection :: String -> Int -> ControllerShape -> IO (S.ToMessageFunc)
+makeConnection deviceName channel cshape = do
+  mid <- getIDForDeviceName deviceName
+  case mid of
+    Nothing -> do putStrLn "List of Available Device Names"
+                  putStrLn =<< displayOutputDevices
+                  error ("Device '" ++ show deviceName ++ "' not found")
+    Just di -> do econn <- outputDevice di (floor $ (*100) $ Sound.Tidal.MIDI.Control.latency cshape)
+                  case econn of
+                    Right err -> error ("Failed opening MIDI Output on Device ID: " ++ show di ++ " - " ++ show err)
+                    Left s -> do
+                      putStrLn ("Successfully initialized Device '" ++ deviceName ++ "'")
+                      sendevents s
+                      return $ (\ shape change tick (o,m) -> do
+                                   let defaulted = (S.applyShape' shape m)
+                                       -- split ParamMap into Properties and Controls
+                                       mpartition = fmap (Map.partitionWithKey (\k _ -> (name k) `elem` ["dur", "note", "velocity", "nudge"])) defaulted
+                                       props = fmap fst mpartition
+                                       ctrls = fmap snd mpartition
+                                       props' = fmap (Map.toAscList) $ fmap (Map.mapMaybe (id)) props
+                                       -- only send explicitly set Control values
+                                       ctrls' = fmap (Map.filterWithKey (\k v -> v /= (defaultValue k))) ctrls
+                                       ctrls'' = fmap (toMidiMap cshape) ctrls'
+                                       send' = fmap (send s channel cshape shape change tick o) ctrls''
+                                   ($) <$> send' <*> props'
+                               )
+
+midiBackend n c cs = do
+  s <- makeConnection n c cs
+  return $ Backend s
+
+midiStream n c s = do
+  backend <- midiBackend n c s
+  stream backend (toShape s)
+
+midiState n c s = do
+  backend <- midiBackend n c s
+  S.state backend (toShape s)
+
+midiSetters :: String -> Int -> ControllerShape -> IO Time -> IO (ParamPattern -> IO (), (Time -> [ParamPattern] -> ParamPattern) -> ParamPattern -> IO ())
+midiSetters n c s getNow = do
+  ds <- midiState n c s
+  return (setter ds, transition getNow ds)
+
+
+-- actual midi interaction
+sendevents :: Output -> IO ThreadId
+sendevents stream = do
+  forkIO $ do loop stream
+    where loop stream = do act stream
+                           delay
+                           loop stream
+          act stream = do
+            let buf = buffer stream
+                o = conn stream
+            buf' <- tryTakeMVar buf
+            case buf' of
+              Nothing ->  do
+                return Nothing
+              Just [] -> do
+                putMVar buf []
+                return Nothing
+              (Just evts@(x:xs)) -> do
+                midiTime <- PM.time
+                let evts' = sortBy (comparing PM.timestamp) evts
+                    nextTick = fromIntegral $ midiTime + 1 -- advance on millisecond, i.e. the next call of this loop
+                    (evts'',later) = span (\x -> (((PM.timestamp x) < midiTime)) || ((PM.timestamp x) < nextTick)) evts'
+                putMVar buf later
+
+                err <- PM.writeEvents o evts''
+                case err of
+                  PM.NoError -> return Nothing
+                  e -> return $ Just (userError ("Error '" ++ show e ++ "' sending Events: " ++ show evts))
+
+          delay = threadDelay 1000 -- in microseconds, i.e. one millisecond
+
+
+sendctrls  :: Output -> ControllerShape -> CLong -> CULong -> MidiMap -> IO ()
+sendctrls stream shape ch t ctrls = do
+  let ctrls' = filter ((>=0) . snd) $ Map.toList $ Map.mapMaybe (id) ctrls
+  sequence_ $ map (\(param, ctrl) -> makeCtrl stream ch (fromJust $ paramN shape param) (fromIntegral ctrl) t) ctrls' -- FIXME: we should be sure param has ControlChange
+  return ()
+
+sendnote :: RealFrac s => Output -> t -> CLong -> (CLong, CLong, s) -> CULong -> IO ThreadId
+sendnote stream shape ch (note,vel, dur) t =
+  do forkIO $ do noteOn stream ch note vel t
+                 noteOff stream ch note (t + (floor $ 1000 * dur))
+                 return ()
+
+sendmidi :: (Show s, RealFrac s) => Output -> ControllerShape -> CLong -> (CLong, CLong, s) -> CULong -> MidiMap -> IO ()
+sendmidi stream shape ch (128,vel,dur) t ctrls = do
+  sendctrls stream shape ch t ctrls
+  return ()
+sendmidi stream shape ch (note,vel,dur) t ctrls = do
+  sendnote stream shape ch (note,vel,dur) t
+  sendctrls stream shape ch t ctrls
+  return ()
+
+
+-- MIDI Utils
+encodeChannel :: (Bits a, Num a) => a -> a -> a
+encodeChannel ch cc = (((-) ch 1) .|. cc)
+
+
+-- MIDI Messages
+noteOn :: Output -> CLong -> CLong -> CLong -> CULong -> IO (Maybe a)
+noteOn o ch val vel t = do
+  let evt = makeEvent 0x90 val ch vel t
+  sendEvent o evt
+
+noteOff :: Output -> CLong -> CLong -> CULong -> IO (Maybe a)
+noteOff o ch val t = do
+  let evt = makeEvent 0x80 val ch 60 t
+  sendEvent o evt
+
+makeCtrl :: Output -> CLong -> ControlChange -> CLong -> CULong -> IO (Maybe a)
+makeCtrl o ch (CC {midi=midi, range=range}) n t = makeCC o ch (fromIntegral midi) n t
+makeCtrl o ch (NRPN {midi=midi, range=range}) n t = makeNRPN o ch (fromIntegral midi) n t
+-- makeCtrl o ch (C.SysEx {C.midi=midi, C.range=range, C.scalef=f}) n t = makeSysEx o ch (fromIntegral midi) scaledN t
+--   where scaledN = fromIntegral $ (f range (n))
+
+-- This is sending CC
+makeCC :: Output -> CLong -> CLong -> CLong -> CULong -> IO (Maybe a)
+makeCC o ch c n t = do
+  let evt = makeEvent 0xB0 c ch n t
+  sendEvent o evt
+
+-- This is sending NRPN
+makeNRPN :: Output -> CLong -> CLong -> CLong -> CULong -> IO (Maybe a)
+makeNRPN o ch c n t = do
+  let nrpn = makeEvent 0xB0
+      evts = [nrpn 0x63 ch (shift (c .&. 0x3F80) (-7)) t,
+              nrpn 0x62 ch (c .&. 0x7F) t,
+              nrpn 0x06 ch (shift (n .&. 0x3F80) (-7)) t,
+              nrpn 0x26 ch (n .&. 0x7F) t
+             ]
+  mapM (sendEvent o) evts
+  return Nothing
+
+
+-- Port Midi Wrapper
+
+outputDevice :: PM.DeviceID -> Int -> IO (Either Output PM.PMError)
+outputDevice deviceID latency = do
+  PM.initialize
+  now <- getCurrentTime
+  result <- PM.openOutput deviceID latency
+  case result of
+    Left dev ->
+      do
+        info <- PM.getDeviceInfo deviceID
+        putStrLn ("Opened: " ++ show (PM.interface info) ++ ": " ++ show (PM.name info))
+        sem <- newEmptyMVar
+        putMVar sem () -- initially fill MVar to be taken by the first user of this output
+        buffer <- newMVar []
+
+        midiOffset <- PM.time
+
+        let posixNow = realToFrac $ utcTimeToPOSIXSeconds now
+            syncedNow = posixNow - ((0.001*) $ fromIntegral midiOffset)
+        return (Left Output { conn=dev, lock=sem, offset=syncedNow, buffer=buffer })
+    Right err -> return (Right err)
+
+
+makeEvent :: CLong -> CLong -> CLong -> CLong -> CULong -> PM.PMEvent
+makeEvent st n ch v t = PM.PMEvent msg (t)
+  where msg = PM.PMMsg (encodeChannel ch st) (n) (v)
+
+-- now with a semaphore since PortMIDI is NOT thread safe
+sendEvent :: Output -> PM.PMEvent -> IO (Maybe a)
+sendEvent o evt = do
+  let sem = lock o
+      buf = buffer o
+  cbuf <- takeMVar buf
+  putMVar buf (cbuf ++ [evt])
+  return Nothing

--- a/Sound/Tidal/OscStream.hs
+++ b/Sound/Tidal/OscStream.hs
@@ -32,7 +32,7 @@ toOscMap m = Map.map (toOscDatum) (Map.mapMaybe (id) m)
 -- constructs and sends an Osc Message according to the given slang and other params - this is essentially the same as the former toMessage in Stream.hs
 send s slang shape change tick (o, m) = osc
     where
-      osc | timestamp slang == BundleStamp = sendOSC s $ Bundle (ut_to_ntpr logicalOnset) [Message (path slang) oscdata']
+      osc | timestamp slang == BundleStamp = sendOSC s $ Bundle (ut_to_ntpr logicalOnset) [Message (path slang) oscdata]
           | timestamp slang == MessageStamp = sendOSC s $ Message (path slang) oscdata'
           | otherwise = doAt logicalOnset $ sendOSC s $ Message (path slang) oscdata
       oscdata' = ((int32 sec):(int32 usec):oscdata)

--- a/Sound/Tidal/OscStream.hs
+++ b/Sound/Tidal/OscStream.hs
@@ -1,0 +1,63 @@
+module Sound.Tidal.OscStream where
+
+import qualified Data.Map as Map
+import Data.Maybe
+import Sound.Tidal.Tempo (Tempo, cps)
+import Sound.Tidal.Stream
+import Sound.Tidal.Utils
+import GHC.Float (float2Double, double2Float)
+import Sound.OSC.FD
+import Sound.OSC.Datum
+
+data TimeStamp = BundleStamp | MessageStamp | NoStamp
+ deriving Eq
+
+data OscSlang = OscSlang {path :: String,
+                          timestamp :: TimeStamp,
+                          namedParams :: Bool,
+                          preamble :: [Datum]
+                         }
+
+type OscMap = Map.Map Param (Maybe Datum)
+
+toOscDatum :: Value -> Maybe Datum
+toOscDatum (VF x) = Just $ float x
+toOscDatum (VI x) = Just $ int32 x
+toOscDatum (VS x) = Just $ string x
+
+toOscMap :: ParamMap -> OscMap
+toOscMap m = Map.map (toOscDatum) (Map.mapMaybe (id) m)
+
+
+-- constructs and sends an Osc Message according to the given slang and other params - this is essentially the same as the former toMessage in Stream.hs
+send s slang shape change tick (o, m) = osc
+    where
+      osc | timestamp slang == BundleStamp = sendOSC s $ Bundle (ut_to_ntpr logicalOnset) [Message (path slang) oscdata']
+          | timestamp slang == MessageStamp = sendOSC s $ Message (path slang) oscdata'
+          | otherwise = doAt logicalOnset $ sendOSC s $ Message (path slang) oscdata
+      oscdata' = ((int32 sec):(int32 usec):oscdata)
+      oscdata = cpsPrefix ++ preamble slang ++ (parameterise $ catMaybes $ mapMaybe (\x -> Map.lookup x m) (params shape))
+      cpsPrefix | cpsStamp shape = [float (cps change)]
+                | otherwise = []
+      parameterise :: [Datum] -> [Datum]
+      parameterise ds | namedParams slang =
+                                    mergelists (map (string . name) (params shape)) ds
+                      | otherwise = ds
+      usec = floor $ 1000000 * (logicalOnset - (fromIntegral sec))
+      sec = floor logicalOnset
+      logicalOnset = logicalOnset' change tick o ((latency shape) + nudge)
+      nudge = maybe 0 (toF) (Map.lookup (F "nudge" (Just 0)) m)
+      toF (Just (Float f)) = float2Double f
+      toF _ = 0
+
+-- Returns a function that will convert a generic ParamMap into a specific Osc message and send it over UDP to the supplied server
+-- messages will be built according to the given OscSlang
+makeConnection :: String -> Int -> OscSlang -> IO (ToMessageFunc)
+makeConnection address port slang = do
+  s <- openUDP address port
+  return (\ shape change tick (o,m) -> do
+             -- this might result in Nothing, make sure we do this first
+             m' <- fmap (toOscMap) (applyShape' shape m)
+             -- to allow us to simplify `send` (no `do`)
+             return $ send s slang shape change tick (o,m')
+         )

--- a/Sound/Tidal/Params.hs
+++ b/Sound/Tidal/Params.hs
@@ -2,115 +2,112 @@ module Sound.Tidal.Params where
 
 import Sound.Tidal.Stream
 import Sound.Tidal.Pattern
-import Sound.OSC.FD
-import Sound.OSC.Datum
 import Data.Map as Map
 
-make' :: (a -> Datum) -> Param -> Pattern a -> OscPattern
-make' toOsc par p = fmap (\x -> Map.singleton par (defaultV x)) p
-  where defaultV a = Just $ toOsc a
+make' :: (a -> Value) -> Param -> Pattern a -> ParamPattern
+make' toValue par p = fmap (\x -> Map.singleton par (defaultV x)) p
+  where defaultV a = Just $ toValue a
 
-sound :: Pattern String -> OscPattern
-sound = make' string sound_p
+sound :: Pattern String -> ParamPattern
+sound = make' VS sound_p
 sound_p = S "sound" Nothing
 
-offset :: Pattern Double -> OscPattern
-offset = make' float offset_p
+offset :: Pattern Double -> ParamPattern
+offset = make' VF offset_p
 offset_p = F "offset" (Just 0)
 
-begin :: Pattern Double -> OscPattern
-begin = make' float begin_p
+begin :: Pattern Double -> ParamPattern
+begin = make' VF begin_p
 begin_p = F "begin" (Just 0)
 
-end :: Pattern Double -> OscPattern
-end = make' float end_p
+end :: Pattern Double -> ParamPattern
+end = make' VF end_p
 end_p = F "end" (Just 1)
 
-speed :: Pattern Double -> OscPattern
-speed = make' float speed_p
+speed :: Pattern Double -> ParamPattern
+speed = make' VF speed_p
 speed_p = F "speed" (Just 1)
 
-pan :: Pattern Double -> OscPattern
-pan = make' float pan_p
+pan :: Pattern Double -> ParamPattern
+pan = make' VF pan_p
 pan_p = F "pan" (Just 0.5)
 
-velocity :: Pattern Double -> OscPattern
-velocity = make' float velocity_p
+velocity :: Pattern Double -> ParamPattern
+velocity = make' VF velocity_p
 velocity_p = F "velocity" (Just 0)
 
-vowel :: Pattern String -> OscPattern
-vowel = make' string vowel_p
+vowel :: Pattern String -> ParamPattern
+vowel = make' VS vowel_p
 vowel_p = S "vowel" (Just "")
 
-cutoff :: Pattern Double -> OscPattern
-cutoff = make' float cutoff_p
+cutoff :: Pattern Double -> ParamPattern
+cutoff = make' VF cutoff_p
 cutoff_p = F "cutoff" (Just 0)
 
-resonance :: Pattern Double -> OscPattern
-resonance = make' float resonance_p
+resonance :: Pattern Double -> ParamPattern
+resonance = make' VF resonance_p
 resonance_p = F "resonance" (Just 0)
 
-accelerate :: Pattern Double -> OscPattern
-accelerate = make' float accelerate_p
+accelerate :: Pattern Double -> ParamPattern
+accelerate = make' VF accelerate_p
 accelerate_p = F "accelerate" (Just 0)
 
-shape :: Pattern Double -> OscPattern
-shape = make' float shape_p
+shape :: Pattern Double -> ParamPattern
+shape = make' VF shape_p
 shape_p = F "shape" (Just 0)
 
-kriole :: Pattern Int -> OscPattern
-kriole = make' int32 kriole_p
+kriole :: Pattern Int -> ParamPattern
+kriole = make' VI kriole_p
 kriole_p = I "kriole" (Just 0)
 
-gain :: Pattern Double -> OscPattern
-gain = make' float gain_p
+gain :: Pattern Double -> ParamPattern
+gain = make' VF gain_p
 gain_p = F "gain" (Just 1)
 
-cut :: Pattern Int -> OscPattern
-cut = make' int32 cut_p
+cut :: Pattern Int -> ParamPattern
+cut = make' VI cut_p
 cut_p = I "cut" (Just (0))
 
-delay :: Pattern Double -> OscPattern
-delay = make' float delay_p
+delay :: Pattern Double -> ParamPattern
+delay = make' VF delay_p
 delay_p = F "delay" (Just (0))
 
-delaytime :: Pattern Double -> OscPattern
-delaytime = make' float delaytime_p
+delaytime :: Pattern Double -> ParamPattern
+delaytime = make' VF delaytime_p
 delaytime_p = F "delaytime" (Just (-1))
 
-delayfeedback :: Pattern Double -> OscPattern
-delayfeedback = make' float delayfeedback_p
+delayfeedback :: Pattern Double -> ParamPattern
+delayfeedback = make' VF delayfeedback_p
 delayfeedback_p = F "delayfeedback" (Just (-1))
 
-crush :: Pattern Double -> OscPattern
-crush = make' float crush_p
+crush :: Pattern Double -> ParamPattern
+crush = make' VF crush_p
 crush_p = F "crush" (Just 0)
 
-coarse :: Pattern Int -> OscPattern
-coarse = make' int32 coarse_p
+coarse :: Pattern Int -> ParamPattern
+coarse = make' VI coarse_p
 coarse_p = I "coarse" (Just 0)
 
-hcutoff :: Pattern Double -> OscPattern
-hcutoff = make' float hcutoff_p
+hcutoff :: Pattern Double -> ParamPattern
+hcutoff = make' VF hcutoff_p
 hcutoff_p = F "hcutoff" (Just 0)
 
-hresonance :: Pattern Double -> OscPattern
-hresonance = make' float hresonance_p
+hresonance :: Pattern Double -> ParamPattern
+hresonance = make' VF hresonance_p
 hresonance_p = F "hresonance" (Just 0)
 
-bandf :: Pattern Double -> OscPattern
-bandf = make' float bandf_p
+bandf :: Pattern Double -> ParamPattern
+bandf = make' VF bandf_p
 bandf_p = F "bandf" (Just 0)
 
-bandq :: Pattern Double -> OscPattern
-bandq = make' float bandq_p
+bandq :: Pattern Double -> ParamPattern
+bandq = make' VF bandq_p
 bandq_p = F "bandq" (Just 0)
 
-unit :: Pattern String -> OscPattern
-unit = make' string unit_p
+unit :: Pattern String -> ParamPattern
+unit = make' VS unit_p
 unit_p = S "unit" (Just "rate")
 
-loop :: Pattern Int -> OscPattern
-loop = make' int32 loop_p
+loop :: Pattern Int -> ParamPattern
+loop = make' VI loop_p
 loop_p = I "loop" (Just 1)
-

--- a/Sound/Tidal/Params.hs
+++ b/Sound/Tidal/Params.hs
@@ -34,7 +34,7 @@ pan_p = F "pan" (Just 0.5)
 
 velocity :: Pattern Double -> ParamPattern
 velocity = make' VF velocity_p
-velocity_p = F "velocity" (Just 0)
+velocity_p = F "velocity" (Just 0.5)
 
 vowel :: Pattern String -> ParamPattern
 vowel = make' VS vowel_p

--- a/Sound/Tidal/SerialStream.hs
+++ b/Sound/Tidal/SerialStream.hs
@@ -60,7 +60,7 @@ useOutput outsM name = do
       putStrLn "Cached Serial Device output"
       return $ Just o
     Nothing -> do
-      o <- Serial.openSerial name Serial.defaultSerialSettings
+      o <- Serial.openSerial name Serial.defaultSerialSettings { Serial.commSpeed = Serial.CS115200 }
       swapMVar outsM $ Map.insert name o outs
       return $ Just o
 
@@ -111,5 +111,5 @@ blinken = Shape {
      light_p
      ],
   cpsStamp = True,
-  latency = (-0.6)
+  latency = 0.01
   }

--- a/Sound/Tidal/SerialStream.hs
+++ b/Sound/Tidal/SerialStream.hs
@@ -1,0 +1,80 @@
+module Sound.Tidal.SerialStream where
+
+import Data.List
+import Data.Maybe
+import qualified Data.Map.Strict as Map
+
+import qualified Data.ByteString.Char8 as B
+import qualified System.Hardware.Serialport as Serial
+
+import Sound.Tidal.Time
+import Sound.Tidal.Stream
+import Sound.Tidal.Transition
+import Sound.Tidal.Pattern
+import Sound.Tidal.Params
+
+type SerialMap = Map.Map Param (Maybe String)
+
+toSerialString :: Value -> Maybe String
+toSerialString (VF x) = Just $ show x
+toSerialString (VI x) = Just $ show x
+toSerialString (VS x) = Just $ x
+
+toSerialMap :: ParamMap -> SerialMap
+toSerialMap m = Map.map (toSerialString) (Map.mapMaybe (id) m)
+
+send' s content = do
+  Serial.send s $ B.pack $ content ++ "\n"
+  return ()
+
+
+send s shape change tick (o, m) = msg
+  where
+    msg = doAt logicalOnset $ send' s params''
+    -- get the first value of the first param for now
+    params'' = case length params' of
+      0 -> ""
+      _ -> head $ params'
+    params' = catMaybes $ map snd $ Map.toList m
+    logicalOnset = logicalOnset' change tick o ((latency shape))
+    -- nudge = maybe 0 (toF) (Map.lookup (F "nudge" (Just 0)) m)
+    -- toF (Just (VF f)) = f
+    -- toF _ = 0
+
+
+
+makeConnection :: String -> IO (ToMessageFunc)
+makeConnection device = do
+  s <- Serial.openSerial device Serial.defaultSerialSettings
+  return (\ shape change tick (o, m) -> do
+             m' <- fmap (toSerialMap) (applyShape' shape m)
+             return $ send s shape change tick (o, m')
+         )
+serialBackend n = do
+  s <- makeConnection n
+  return $ Backend s
+
+blinkenStream n = do
+  backend <- serialBackend n
+  stream backend blinken
+
+blinkenState n = do
+  backend <- serialBackend n
+  state backend blinken
+
+blinkenSetters :: String -> IO Time -> IO (ParamPattern -> IO (), (Time -> [ParamPattern] -> ParamPattern) -> ParamPattern -> IO ())
+blinkenSetters n getNow = do
+  ds <- blinkenState n
+  return (setter ds, transition getNow ds)
+
+light :: Pattern String -> ParamPattern
+light = make' VS light_p
+light_p = S "light" Nothing
+
+blinken = Shape {
+  params = [
+     light_p
+     ],
+  cpsStamp = True,
+  latency = 0.01
+  }

--- a/Sound/Tidal/SerialStream.hs
+++ b/Sound/Tidal/SerialStream.hs
@@ -46,10 +46,10 @@ send s shape change tick (o, m) = msg
       0 -> ""
       _ -> head $ params'
     params' = catMaybes $ map snd $ Map.toList m
-    logicalOnset = logicalOnset' change tick o ((latency shape))
-    -- nudge = maybe 0 (toF) (Map.lookup (F "nudge" (Just 0)) m)
-    -- toF (Just (VF f)) = f
-    -- toF _ = 0
+    logicalOnset = logicalOnset' change tick o ((latency shape) + nudge)
+    nudge = maybe 0 (toF) (Map.lookup (F "nudge" (Just 0)) m)
+    toF (Just s) = read s
+    toF _ = 0
 
 
 useOutput outsM name = do
@@ -83,8 +83,6 @@ serialDevices = do
   d <- newMVar $ Map.fromList []
   return d
 
-
-  --  return
 serialBackend d n = do
   s <- makeConnection d n
   return $ Backend s

--- a/Sound/Tidal/SerialStream.hs
+++ b/Sound/Tidal/SerialStream.hs
@@ -76,5 +76,5 @@ blinken = Shape {
      light_p
      ],
   cpsStamp = True,
-  latency = 0.01
+  latency = 0.1
   }

--- a/Sound/Tidal/Strategies.hs
+++ b/Sound/Tidal/Strategies.hs
@@ -13,7 +13,6 @@ import Sound.Tidal.Stream
 import Sound.Tidal.Time
 import Sound.Tidal.Utils
 import Sound.Tidal.Params
-import qualified Sound.OSC.FD as OSC.FD
 
 stutter n t p = stack $ map (\i -> (t * (fromIntegral i)) ~> p) [0 .. (n-1)]
 
@@ -23,7 +22,7 @@ quad   = stutter 4
 double = echo
 
 jux f p = stack [p # pan (pure 0), f $ p # pan (pure 1)]
-juxcut f p = stack [p     # pan (pure 0) # cut (pure (-1)), 
+juxcut f p = stack [p     # pan (pure 0) # cut (pure (-1)),
                     f $ p # pan (pure 1) # cut (pure (-2))
                    ]
 
@@ -54,7 +53,7 @@ samples' p p' = (flip pick) <$> p' <*> p
 {-
 scrumple :: Time -> Pattern a -> Pattern a -> Pattern a
 scrumple o p p' = p'' -- overlay p (o ~> p'')
-  where p'' = Pattern $ \a -> concatMap 
+  where p'' = Pattern $ \a -> concatMap
                               (\((s,d), vs) -> map (\x -> ((s,d),
                                                            snd x
                                                           )
@@ -64,15 +63,15 @@ scrumple o p p' = p'' -- overlay p (o ~> p'')
 -}
 
 --rev :: Pattern a -> Pattern a
---rev p = Pattern $ \a -> concatMap 
---                        (\a' -> mapFsts mirrorArc $ 
+--rev p = Pattern $ \a -> concatMap
+--                        (\a' -> mapFsts mirrorArc $
 --                                (arc p (mirrorArc a')))
 --                        (arcCycles a)
 
 --spreadf :: [Pattern a -> Pattern b] -> Pattern a -> Pattern b
 spreadf ts p = spread ($)
 
-spin :: Int -> OscPattern -> OscPattern
+spin :: Int -> ParamPattern -> ParamPattern
 spin copies p =
   stack $ map (\n -> let offset = toInteger n % toInteger copies in
                      offset <~ p
@@ -107,19 +106,19 @@ inside n f p = density n $ f (slow n p)
 scale :: (Functor f, Num b) => b -> b -> f b -> f b
 scale from to p = ((+ from) . (* (to-from))) <$> p
 
-chop :: Int -> OscPattern -> OscPattern
+chop :: Int -> ParamPattern -> ParamPattern
 chop n p = Pattern $ \queryA -> concatMap (f queryA) $ arcCycles queryA
      where f queryA a = concatMap (chopEvent queryA) (arc p a)
            chopEvent (queryS, queryE) (a,a',v) = map (newEvent v) $ filter (\(_, (s,e)) -> not $ or [e < queryS, s >= queryE]) (enumerate $ chopArc a n)
-           newEvent :: OscMap -> (Int, Arc) -> Event OscMap
-           newEvent v (i, a) = (a,a,Map.insert (param dirt "end") (Just $ OSC.FD.float ((fromIntegral $ i+1)/(fromIntegral n))) $ Map.insert (param dirt "begin") (Just $ OSC.FD.float ((fromIntegral i)/(fromIntegral n))) v)
+           newEvent :: ParamMap -> (Int, Arc) -> Event ParamMap
+           newEvent v (i, a) = (a,a,Map.insert (param dirt "end") (Just $ VF ((fromIntegral $ i+1)/(fromIntegral n))) $ Map.insert (param dirt "begin") (Just $ VF ((fromIntegral i)/(fromIntegral n))) v)
 
-gap :: Int -> OscPattern -> OscPattern
+gap :: Int -> ParamPattern -> ParamPattern
 gap n p = Pattern $ \queryA -> concatMap (f queryA) $ arcCycles queryA
      where f queryA a = concatMap (chopEvent queryA) (arc p a)
            chopEvent (queryS, queryE) (a,a',v) = map (newEvent v) $ filter (\(_, (s,e)) -> not $ or [e < queryS, s >= queryE]) (enumerate $ everyOther $ chopArc a n)
-           newEvent :: OscMap -> (Int, Arc) -> Event OscMap
-           newEvent v (i, a) = (a,a,Map.insert (param dirt "end") (Just $ OSC.FD.float ((fromIntegral $ i+1)/(fromIntegral n))) $ Map.insert (param dirt "begin") (Just $ OSC.FD.float ((fromIntegral i)/(fromIntegral n))) v)
+           newEvent :: ParamMap -> (Int, Arc) -> Event ParamMap
+           newEvent v (i, a) = (a,a,Map.insert (param dirt "end") (Just $ VF ((fromIntegral $ i+1)/(fromIntegral n))) $ Map.insert (param dirt "begin") (Just $ VF ((fromIntegral i)/(fromIntegral n))) v)
            everyOther (x:(y:xs)) = x:(everyOther xs)
            everyOther xs = xs
 
@@ -127,7 +126,7 @@ chopArc :: Arc -> Int -> [Arc]
 chopArc (s, e) n = map (\i -> ((s + (e-s)*(fromIntegral i/fromIntegral n)), s + (e-s)*((fromIntegral $ i+1)/fromIntegral n))) [0 .. n-1]
 {-
 normEv :: Event a -> Event a -> Event a
-normEv ev@(_, (s,e), _) ev'@(_, (s',e'), _) 
+normEv ev@(_, (s,e), _) ev'@(_, (s',e'), _)
        | not on && not off = [] -- shouldn't happen
        | on && off = splitEv ev'
        | not on && s' > sam s = []
@@ -148,7 +147,7 @@ normEv ev@(_, (s,e), _) ev'@(_, (s',e'), _)
 en :: [(Int, Int)] -> Pattern String -> Pattern String
 en ns p = stack $ map (\(i, (k, n)) -> e k n (samples p (pure i))) $ enumerate ns
 
-weave :: Rational -> OscPattern -> [OscPattern] -> OscPattern
+weave :: Rational -> ParamPattern -> [ParamPattern] -> ParamPattern
 weave t p ps = weave' t p (map (\x -> (x #)) ps)
 
 weave' :: Rational -> Pattern a -> [Pattern a -> Pattern a] -> Pattern a
@@ -156,7 +155,7 @@ weave' t p fs | l == 0 = silence
               | otherwise = slow t $ stack $ map (\(i, f) -> (fromIntegral i % l) <~ (density t $ f (slow t p))) (zip [0 ..] fs)
   where l = fromIntegral $ length fs
 
-interlace :: OscPattern -> OscPattern -> OscPattern
+interlace :: ParamPattern -> ParamPattern -> ParamPattern
 interlace a b = weave 16 (shape $ ((* 0.9) <$> sinewave1)) [a, b]
 
 -- Step sequencing
@@ -175,7 +174,7 @@ off t f p = superimpose (f . (t ~>)) p
 offadd :: Num a => Time -> a -> Pattern a -> Pattern a
 offadd t n p = off t ((+n) <$>) p
 
-up :: Pattern Double -> OscPattern
+up :: Pattern Double -> ParamPattern
 up = speed . ((1.059466**) <$>)
 
 ghost'' a f p = superimpose (((a*2.5) ~>) . f) $ superimpose (((a*1.5) ~>) . f) $ p

--- a/Sound/Tidal/Stream.hs
+++ b/Sound/Tidal/Stream.hs
@@ -3,8 +3,6 @@
 module Sound.Tidal.Stream where
 
 import Data.Maybe
-import Sound.OSC.FD
-import Sound.OSC.Datum
 import Control.Applicative
 import Control.Concurrent
 import Control.Concurrent.MVar
@@ -12,15 +10,19 @@ import Control.Exception as E
 import Data.Time (getCurrentTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Ratio
-import GHC.Float (float2Double, double2Float)
 import Sound.Tidal.Pattern
 import qualified Sound.Tidal.Parse as P
 import Sound.Tidal.Tempo (Tempo, logicalTime, clocked,clockedTick,cps)
 import Sound.Tidal.Utils
 import qualified Sound.Tidal.Time as T
-import qualified Data.ByteString as BS
 
 import qualified Data.Map as Map
+
+type ToMessageFunc = Shape -> Tempo -> Int -> (Double, ParamMap) -> Maybe (IO ())
+
+data Backend a = Backend {
+  toMessage :: ToMessageFunc
+  }
 
 data Param = S {name :: String, sDefault :: Maybe String}
            | F {name :: String, fDefault :: Maybe Double}
@@ -34,28 +36,24 @@ instance Ord Param where
 instance Show Param where
   show p = name p
 
-data TimeStamp = BundleStamp | MessageStamp | NoStamp
- deriving Eq
+data Shape = Shape {params :: [Param],
+                    latency :: Double,
+                    cpsStamp :: Bool}
 
-data OscShape = OscShape {path :: String,
-                          params :: [Param],
-                          cpsStamp :: Bool,
-                          timestamp :: TimeStamp,
-                          latency :: Double,
-                          namedParams :: Bool,
-                          preamble :: [Datum]
-                         }
-type OscMap = Map.Map Param (Maybe Datum)
 
-type OscPattern = Pattern OscMap
+data Value = VS { svalue :: String } | VF { fvalue :: Double } | VI { ivalue :: Int } deriving (Show,Eq,Ord)
+
+type ParamMap = Map.Map Param (Maybe Value)
+
+type ParamPattern = Pattern ParamMap
 
 ticksPerCycle = 8
 
-defaultDatum :: Param -> Maybe Datum
-defaultDatum (S _ (Just x)) = Just $ string x
-defaultDatum (I _ (Just x)) = Just $ int32 x
-defaultDatum (F _ (Just x)) = Just $ float x
-defaultDatum _ = Nothing
+defaultValue :: Param -> Maybe Value
+defaultValue (S _ (Just x)) = Just $ VS x
+defaultValue (I _ (Just x)) = Just $ VI x
+defaultValue (F _ (Just x)) = Just $ VF x
+defaultValue _ = Nothing
 
 hasDefault :: Param -> Bool
 hasDefault (S _ Nothing) = False
@@ -63,138 +61,120 @@ hasDefault (I _ Nothing) = False
 hasDefault (F _ Nothing) = False
 hasDefault _ = True
 
-defaulted :: OscShape -> [Param]
+defaulted :: Shape -> [Param]
 defaulted = filter hasDefault . params
 
-defaultMap :: OscShape -> OscMap
+defaultMap :: Shape -> ParamMap
 defaultMap s
-  = Map.fromList $ map (\x -> (x, defaultDatum x)) (defaulted s)
+  = Map.fromList $ map (\x -> (x, defaultValue x)) (defaulted s)
 
-required :: OscShape -> [Param]
+required :: Shape -> [Param]
 required = filter (not . hasDefault) . params
 
-hasRequired :: OscShape -> OscMap -> Bool
+hasRequired :: Shape -> ParamMap -> Bool
 hasRequired s m = isSubset (required s) (Map.keys (Map.filter (\x -> x /= Nothing) m))
 
 isSubset :: (Eq a) => [a] -> [a] -> Bool
 isSubset xs ys = all (\x -> elem x ys) xs
 
-toMessage :: UDP -> OscShape -> Tempo -> Int -> (Double, OscMap) -> Maybe (IO ())
-toMessage s shape change tick (o, m) =
-  do m' <- applyShape' shape m
-     let cycleD = ((fromIntegral tick) / (fromIntegral ticksPerCycle)) :: Double
-         logicalNow = (logicalTime change cycleD)
-         logicalPeriod = (logicalTime change (cycleD + (1/(fromIntegral ticksPerCycle)))) - logicalNow
-         logicalOnset = logicalNow + (logicalPeriod * o) + (latency shape) + nudge
-         sec = floor logicalOnset
-         usec = floor $ 1000000 * (logicalOnset - (fromIntegral sec))
-         oscdata = cpsPrefix ++ preamble shape ++ (parameterise $ catMaybes $ mapMaybe (\x -> Map.lookup x m') (params shape))
-         oscdata' = ((int32 sec):(int32 usec):oscdata)
-         osc | timestamp shape == BundleStamp = sendOSC s $ Bundle (ut_to_ntpr logicalOnset) [Message (path shape) oscdata]
-             | timestamp shape == MessageStamp = sendOSC s $ Message (path shape) oscdata'
-             | otherwise = doAt logicalOnset $ sendOSC s $ Message (path shape) oscdata
-     return osc
-     where
-       parameterise :: [Datum] -> [Datum]
-       parameterise ds | namedParams shape =
-                               mergelists (map (string . name) (params shape)) ds
-                       | otherwise = ds
-       cpsPrefix | cpsStamp shape = [float (cps change)]
-                 | otherwise = []
-       nudge = maybe 0 (toF) (Map.lookup (F "nudge" (Just 0)) m)
-       toF (Just (Float f)) = float2Double f
-       toF _ = 0
 
 doAt t action = do forkIO $ do now <- getCurrentTime
                                let nowf = realToFrac $ utcTimeToPOSIXSeconds now
                                threadDelay $ floor $ (t - nowf) * 1000000
                                action
                    return ()
-                       
-applyShape' :: OscShape -> OscMap -> Maybe OscMap
+
+logicalOnset' change tick o offset = logicalNow + (logicalPeriod * o) + offset
+  where
+    tpc = fromIntegral ticksPerCycle
+    cycleD = ((fromIntegral tick) / tpc) :: Double
+    logicalNow = logicalTime change cycleD
+    logicalPeriod = (logicalTime change (cycleD + (1/tpc))) - logicalNow
+
+
+applyShape' :: Shape -> ParamMap -> Maybe ParamMap
 applyShape' s m | hasRequired s m = Just $ Map.union m (defaultMap s)
                 | otherwise = Nothing
 
-start :: String -> Int -> OscShape -> IO (MVar (OscPattern))
-start address port shape
+start :: Backend a -> Shape -> IO (MVar (ParamPattern))
+start backend shape
   = do patternM <- newMVar silence
-       s <- openUDP address port
-       let ot = (onTick s shape patternM) :: Tempo -> Int -> IO ()
+       let ot = (onTick backend shape patternM) :: Tempo -> Int -> IO ()
        forkIO $ clockedTick ticksPerCycle ot
        return patternM
 
 -- variant of start where history of patterns is available
-state :: String -> Int -> OscShape -> IO (MVar (OscPattern, [OscPattern]))
-state address port shape
+state :: Backend a -> Shape -> IO (MVar (ParamPattern, [ParamPattern]))
+state backend shape
   = do patternsM <- newMVar (silence, [])
-       s <- openUDP address port
-       let ot = (onTick' s shape patternsM) :: Tempo -> Int -> IO ()
+       let ot = (onTick' backend shape patternsM) :: Tempo -> Int -> IO ()
        forkIO $ clockedTick ticksPerCycle ot
        return patternsM
 
-stream :: String -> Int -> OscShape -> IO (OscPattern -> IO ())
-stream address port shape 
-  = do patternM <- start address port shape
+stream :: Backend a -> Shape -> IO (ParamPattern -> IO ())
+stream backend shape
+  = do patternM <- start backend shape
        return $ \p -> do swapMVar patternM p
                          return ()
 
-streamcallback :: (OscPattern -> IO ()) -> String -> Int -> OscShape -> IO (OscPattern -> IO ())
-streamcallback callback server port shape 
-  = do f <- stream server port shape
+streamcallback :: (ParamPattern -> IO ()) -> Backend a -> Shape -> IO (ParamPattern -> IO ())
+streamcallback callback backend shape
+  = do f <- stream backend shape
        let f' p = do callback p
                      f p
        return f'
 
-onTick :: UDP -> OscShape -> MVar (OscPattern) -> Tempo -> Int -> IO ()
-onTick s shape patternM change ticks
+onTick :: Backend a -> Shape -> MVar (ParamPattern) -> Tempo -> Int -> IO ()
+onTick backend shape patternM change ticks
   = do p <- readMVar patternM
        let ticks' = (fromIntegral ticks) :: Integer
            a = ticks' % ticksPerCycle
            b = (ticks' + 1) % ticksPerCycle
-           messages = mapMaybe 
-                      (toMessage s shape change ticks) 
+           messages = mapMaybe
+                      (toMessage backend shape change ticks)
                       (seqToRelOnsets (a, b) p)
        E.catch (sequence_ messages) (\msg -> putStrLn $ "oops " ++ show (msg :: E.SomeException))
        return ()
 
 -- Variant where mutable variable contains list as history of the patterns
-onTick' :: UDP -> OscShape -> MVar (OscPattern, [OscPattern]) -> Tempo -> Int -> IO ()
-onTick' s shape patternsM change ticks
+onTick' :: Backend a -> Shape -> MVar (ParamPattern, [ParamPattern]) -> Tempo -> Int -> IO ()
+onTick' backend shape patternsM change ticks
   = do ps <- readMVar patternsM
        let ticks' = (fromIntegral ticks) :: Integer
+           toM = (toMessage backend)
            a = ticks' % ticksPerCycle
            b = (ticks' + 1) % ticksPerCycle
-           messages = mapMaybe 
-                      (toMessage s shape change ticks) 
+           messages = mapMaybe
+                      (toM shape change ticks)
                       (seqToRelOnsets (a, b) $ fst ps)
        E.catch (sequence_ messages) (\msg -> putStrLn $ "oops " ++ show (msg :: E.SomeException))
        return ()
 
-make :: (a -> Datum) -> OscShape -> String -> Pattern a -> OscPattern
-make toOsc s nm p = fmap (\x -> Map.singleton nParam (defaultV x)) p
+make :: (a -> Value) -> Shape -> String -> Pattern a -> ParamPattern
+make toValue s nm p = fmap (\x -> Map.singleton nParam (defaultV x)) p
   where nParam = param s nm
-        defaultV a = Just $ toOsc a
-        --defaultV Nothing = defaultDatum nParam
+        defaultV a = Just $ toValue a
+        --defaultV Nothing = defaultValue nParam
 
-nudge :: Pattern Double -> OscPattern
-nudge p = fmap (\x -> Map.singleton (F "nudge" (Just 0)) (Just $ float x)) p
- 
-makeS = make string
+nudge :: Pattern Double -> ParamPattern
+nudge p = fmap (\x -> Map.singleton (F "nudge" (Just 0)) (Just $ VF x)) p
 
-makeF :: OscShape -> String -> Pattern Double -> OscPattern
-makeF = make float
+makeS = make VS
 
-makeI :: OscShape -> String -> Pattern Int -> OscPattern
-makeI = make int32
+makeF :: Shape -> String -> Pattern Double -> ParamPattern
+makeF = make VF
 
-param :: OscShape -> String -> Param
+makeI :: Shape -> String -> Pattern Int -> ParamPattern
+makeI = make VI
+
+param :: Shape -> String -> Param
 param shape n = head $ filter (\x -> name x == n) (params shape)
 
-merge :: OscPattern -> OscPattern -> OscPattern
+merge :: ParamPattern -> ParamPattern -> ParamPattern
 merge x y = (flip Map.union) <$> x <*> y
 
 infixl 1 |=|
-(|=|) :: OscPattern -> OscPattern -> OscPattern
+(|=|) :: ParamPattern -> ParamPattern -> ParamPattern
 (|=|) = merge
 
 (#) = (|=|)
@@ -207,31 +187,31 @@ mergeWith
      -> f (Map.Map k a) -> f (Map.Map k a) -> f (Map.Map k a)
 
 mergeNumWith intOp floatOp = mergeWith f
-  where f (F _ _) (Just (Float a)) (Just (Float b)) = Just (Float $ floatOp a b)
-        f (I _ _) (Just (Int32 a)) (Just (Int32 b)) = Just (Int32 $ intOp a b)
+  where f (F _ _) (Just (VF a)) (Just (VF b)) = Just (VF $ floatOp a b)
+        f (I _ _) (Just (VI a)) (Just (VI b)) = Just (VI $ intOp a b)
         f _ _ b = b
 
 mergePlus = mergeWith f
-  where f (F _ _) (Just (Float a)) (Just (Float b)) = Just (Float $ a + b)
-        f (I _ _) (Just (Int32 a)) (Just (Int32 b)) = Just (Int32 $ a + b)
-        f (S _ _) (Just (ASCII_String a)) (Just (ASCII_String b)) = Just (ASCII_String $ BS.append a b)
+  where f (F _ _) (Just (VF a)) (Just (VF b)) = Just (VF $ a + b)
+        f (I _ _) (Just (VI a)) (Just (VI b)) = Just (VI $ a + b)
+        f (S _ _) (Just (VS a)) (Just (VS b)) = Just (VS $ a ++ b)
         f _ _ b = b
 
 
 infixl 1 |*|
-(|*|) :: OscPattern -> OscPattern -> OscPattern
+(|*|) :: ParamPattern -> ParamPattern -> ParamPattern
 (|*|) = mergeNumWith (*) (*)
 
 infixl 1 |+|
-(|+|) :: OscPattern -> OscPattern -> OscPattern
+(|+|) :: ParamPattern -> ParamPattern -> ParamPattern
 (|+|) = mergePlus
 
 infixl 1 |-|
-(|-|) :: OscPattern -> OscPattern -> OscPattern
+(|-|) :: ParamPattern -> ParamPattern -> ParamPattern
 (|-|) = mergeNumWith (-) (-)
 
 infixl 1 |/|
-(|/|) :: OscPattern -> OscPattern -> OscPattern
+(|/|) :: ParamPattern -> ParamPattern -> ParamPattern
 (|/|) = mergeNumWith (div) (/)
 
 setter :: MVar (a, [a]) -> a -> IO ()

--- a/Sound/Tidal/Synth.hs
+++ b/Sound/Tidal/Synth.hs
@@ -12,7 +12,7 @@ synthController = ControllerShape {
     mCC expression_p 11,
     mCC sustainpedal_p 64
      ],
-  latency = 0.1
+  latency = 0.01
   }
 
 synth = toShape synthController

--- a/Sound/Tidal/Synth.hs
+++ b/Sound/Tidal/Synth.hs
@@ -1,0 +1,18 @@
+module Sound.Tidal.Synth where
+
+import Sound.Tidal.Params
+import Sound.Tidal.MIDI.Control
+import Sound.Tidal.MIDI.Params
+
+synthController :: ControllerShape
+synthController = ControllerShape {
+  controls = [
+    mCC modwheel_p 1,
+    mCC pan_p 10,
+    mCC expression_p 11,
+    mCC sustainpedal_p 64
+     ],
+  latency = 0.1
+  }
+
+synth = toShape synthController

--- a/Sound/Tidal/Transition.hs
+++ b/Sound/Tidal/Transition.hs
@@ -1,6 +1,5 @@
 module Sound.Tidal.Transition where
 
-import Sound.Tidal.Dirt
 import Sound.Tidal.Stream
 import Sound.Tidal.Pattern
 import Sound.Tidal.Time
@@ -12,7 +11,7 @@ import Control.Applicative
 
 import Data.Monoid
 
-transition :: (IO Time) -> MVar (OscPattern, [OscPattern]) -> (Time -> [OscPattern] -> OscPattern) -> OscPattern -> IO ()
+transition :: (IO Time) -> MVar (ParamPattern, [ParamPattern]) -> (Time -> [ParamPattern] -> ParamPattern) -> ParamPattern -> IO ()
 transition getNow mv f p =
   do now <- getNow
      ps <- takeMVar mv
@@ -24,7 +23,7 @@ transition getNow mv f p =
      return ()
 
 -- Pans the last n versions of the pattern across the field
-histpan :: Int -> Time -> [OscPattern] -> OscPattern
+histpan :: Int -> Time -> [ParamPattern] -> ParamPattern
 histpan _ _ [] = silence
 histpan 0 _ _ = silence
 histpan n _ ps = stack $ map (\(i,p) -> p # pan (atom $ (fromIntegral i) / (fromIntegral n'))) (enumerate ps')
@@ -36,7 +35,7 @@ histpan n _ ps = stack $ map (\(i,p) -> p # pan (atom $ (fromIntegral i) / (from
 superwash :: (Pattern a -> Pattern a) -> (Pattern a -> Pattern a) -> Time -> Time -> Time -> [Pattern a] -> Pattern a
 superwash _ _ _ _ _ [] = silence
 superwash _ _ _ _ _ (p:[]) = p
-superwash fout fin delay dur now (p:p':_) = 
+superwash fout fin delay dur now (p:p':_) =
    (playWhen (< (now + delay)) p') <>
    (playWhen (between (now + delay) (now + delay + dur)) $ fout p') <>
    (playWhen (>= (now + delay + dur)) $ fin p)
@@ -48,38 +47,28 @@ wash _ _ _ [] = silence
 wash _ _ _ (p:[]) = p
 wash f t now (p:p':_) = overlay (playWhen (< (now + t)) $ f p') (playWhen (>= (now + t)) p)
 
--- Increase comb filter to anticipate 'drop' to next pattern
-anticipateIn :: Time -> Time -> [OscPattern] -> OscPattern
-anticipateIn t now = wash (spread' (stut 8 0.2) (now ~> (slow t $ (toRational . (1-)) <$> envL))) t now
-
-anticipate :: Time -> [OscPattern] -> OscPattern
-anticipate = anticipateIn 8
 
 -- Just stop for a bit before playing new pattern
-wait :: Time -> Time -> [OscPattern] -> OscPattern
+wait :: Time -> Time -> [ParamPattern] -> ParamPattern
 wait t _ [] = silence
 wait t now (p:_) = playWhen (>= (nextSam (now+t-1))) p
 
 -- transition at cycle boundary after n cycles
-jumpIn' :: Int -> Time -> [OscPattern] -> OscPattern
+jumpIn' :: Int -> Time -> [ParamPattern] -> ParamPattern
 jumpIn' n now = superwash id id ((nextSam now) - now + (fromIntegral n)) 0 now
 
 -- sharp transition a certain number of cycles in the future
-jumpIn :: Int -> Time -> [OscPattern] -> OscPattern
+jumpIn :: Int -> Time -> [ParamPattern] -> ParamPattern
 jumpIn n = superwash id id (fromIntegral n) 0
 
-jump :: Time -> [OscPattern] -> OscPattern
+jump :: Time -> [ParamPattern] -> ParamPattern
 jump = jumpIn 0
 
 -- transition at next cycle boundary where cycle mod n == 0
-jumpMod :: Int -> Time -> [OscPattern] -> OscPattern
+jumpMod :: Int -> Time -> [ParamPattern] -> ParamPattern
 jumpMod n now = jumpIn ((n-1) - ((floor now) `mod` n)) now
 
 -- Degrade the new pattern over time until it goes to nothing
-mortal :: Time -> Time -> Time -> [OscPattern] -> OscPattern
+mortal :: Time -> Time -> Time -> [ParamPattern] -> ParamPattern
 mortal _ _ _ [] = silence
 mortal lifespan release now (p:_) = overlay (playWhen (<(now+lifespan)) p) (playWhen (>= (now+lifespan)) (fadeOut' (now + lifespan) release p))
-
-dirtSetters :: IO Time -> IO (OscPattern -> IO (), (Time -> [OscPattern] -> OscPattern) -> OscPattern -> IO ())
-dirtSetters getNow = do ds <- dirtState
-                        return (setter ds, transition getNow ds)

--- a/tidal.cabal
+++ b/tidal.cabal
@@ -1,7 +1,7 @@
 name:                tidal
 version:             0.7
 synopsis:            Pattern language for improvised music
--- description:         
+-- description:
 homepage:            http://tidal.lurk.org/
 license:             GPL-3
 license-file:        LICENSE
@@ -22,6 +22,12 @@ library
                        Sound.Tidal.Dirt
                        Sound.Tidal.Pattern
                        Sound.Tidal.Stream
+                       Sound.Tidal.OscStream
+                       Sound.Tidal.MidiStream
+                       Sound.Tidal.MIDI.Device
+                       Sound.Tidal.MIDI.Params
+                       Sound.Tidal.MIDI.Control
+                       Sound.Tidal.Synth
                        Sound.Tidal.Parse
                        Sound.Tidal.Tempo
                        Sound.Tidal.Time
@@ -31,4 +37,4 @@ library
                        Sound.Tidal.Params
                        Sound.Tidal.Transition
 
-  Build-depends: base < 5, process, parsec, hosc > 0.13, hashable, colour, containers, time, websockets > 0.8, text, mtl >=2.1, transformers, mersenne-random-pure64,binary, bytestring, hmt
+  Build-depends: base < 5, process, parsec, hosc > 0.13, hashable, colour, containers, time, websockets > 0.8, text, mtl >=2.1, transformers, mersenne-random-pure64,binary, bytestring, hmt, PortMidi >= 0.1.5

--- a/tidal.cabal
+++ b/tidal.cabal
@@ -38,4 +38,4 @@ library
                        Sound.Tidal.Params
                        Sound.Tidal.Transition
 
-  Build-depends: base < 5, process, parsec, hosc > 0.13, hashable, colour, containers, time, websockets > 0.8, text, mtl >=2.1, transformers, mersenne-random-pure64,binary, bytestring, hmt, PortMidi >= 0.1.5, serialport >= 0.4.7
+  Build-depends: base < 5, process, parsec, hosc > 0.13, hashable, colour, containers, time, websockets > 0.8, text, mtl >=2.1, transformers, mersenne-random-pure64,binary, bytestring, hmt, PortMidi >= 0.1.5, serialport >= 0.4.7, signal >= 0.1.0.3

--- a/tidal.cabal
+++ b/tidal.cabal
@@ -38,4 +38,4 @@ library
                        Sound.Tidal.Params
                        Sound.Tidal.Transition
 
-  Build-depends: base < 5, process, parsec, hosc > 0.13, hashable, colour, containers, time, websockets > 0.8, text, mtl >=2.1, transformers, mersenne-random-pure64,binary, bytestring, hmt, PortMidi >= 0.1.5, serialport >= 0.4.7, signal >= 0.1.0.3
+  Build-depends: base < 5, process, parsec, hosc > 0.13, hashable, colour, containers, time, websockets > 0.8, text, mtl >=2.1, transformers, mersenne-random-pure64,binary, bytestring, hmt, PortMidi >= 0.1.5, serialport >= 0.4.7

--- a/tidal.cabal
+++ b/tidal.cabal
@@ -28,6 +28,7 @@ library
                        Sound.Tidal.MIDI.Params
                        Sound.Tidal.MIDI.Control
                        Sound.Tidal.Synth
+                       Sound.Tidal.SerialStream
                        Sound.Tidal.Parse
                        Sound.Tidal.Tempo
                        Sound.Tidal.Time
@@ -37,4 +38,4 @@ library
                        Sound.Tidal.Params
                        Sound.Tidal.Transition
 
-  Build-depends: base < 5, process, parsec, hosc > 0.13, hashable, colour, containers, time, websockets > 0.8, text, mtl >=2.1, transformers, mersenne-random-pure64,binary, bytestring, hmt, PortMidi >= 0.1.5
+  Build-depends: base < 5, process, parsec, hosc > 0.13, hashable, colour, containers, time, websockets > 0.8, text, mtl >=2.1, transformers, mersenne-random-pure64,binary, bytestring, hmt, PortMidi >= 0.1.5, serialport >= 0.4.7


### PR DESCRIPTION
This pull request will allow every stream instance to have a different backend, e.g. OSC, MIDI or possibly others.

Usage shall be the same as before for OSC:

```haskell
(d1, t1) <- dirtSetters getNow
```

for MIDI certain things are arbitrary so you have to pass them on initialization:

```haskell
devices <- midiDevices
(m1,mt1) <- midiSetters devices "SimpleSynth virtual input" 1 synthController getNow
(m2,mt2) <- midiSetters devices "SimpleSynth virtual input" 2 synthController getNow
```
Additional arguments are a list of all available MIDI outputs (`midiDevices`), _Output name_, _channel no._ and `ControllerShape`.

With this generalization in place it is now possible to use params across backends and in case of MIDI across synths.

```haskell
d1 $ sound "bd" # cutoff "0.2" # resonance "0.5"

s1 $ note "69" # cutoff "0.1" # resonance "0.2"

```

### Data types

Data types have been generalized so OSC and MIDI share an underlying `Shape` that defines acceptable params.

The type `OscPattern` is now `ParamPattern` that is protocol agnostic and therefore not bound to OSC. A `Param` itself contains a generic `Value` that can be either `String`, `Double` or `Int`. Each backend specifies how to transform a `ParamPattern` into the corresponding data that is sent across each of the protocols (originally this was all done within `toMessage` in `Stream.hs` and is now up to `OscStream` and `MidiStream`). 

### OSC

An `OscStream` has an additional data type for defining a certain slang spoken across OSC (`OscSlang`) that is defined like this:

```haskell
data OscSlang = OscSlang {path :: String,
                          timestamp :: TimeStamp,
                          namedParams :: Bool,
                          preamble :: [Datum]
                         }
```

This allows alternative communication with OSC receivers e.g. SuperCollider using the same underlying stream `Shape`.

### MIDI

The `MidiStream` allows using a `ControllerShape` that accepts a list of `ControlChange` items. These define mapping from CC number to a named `Param`.

### Serial

__Warning:__ Currently opened serial devices will not be closed by tidal. Depending on the operating system and the serial driver you are using, this could lead to hanging serial connection when closing and reopen tidal. 

The `SerialStream` can be used to communicate with other hardware (e.g. Arduino). The `blinken` demo allows sending a pattern of strings for colors of _light_

```haskell
devices <- serialDevices
(s1,st1) <- blinkenSetters devices "/dev/tty.usbserial" getNow

s1 $ light "red green blue"
```

This will send ASCII messages across serial (9600 baud) containing just a color name each line. __Note:__ This is not scheduled but rather messages are sent via `doAt`.

See [this simple Arduino code for the above Tidal example](https://gist.github.com/lennart/207ad2e1ca6ff8cb6e3a)