### PR TITLE
Extend functionality of toMIDI

### DIFF
--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -11,6 +11,7 @@ import Data.Ratio
 import Debug.Trace
 import Data.Typeable
 import Data.Function
+import Data.Char (digitToInt, isLetter)
 import System.Random.Mersenne.Pure64
 
 import Music.Theory.Bjorklund
@@ -632,6 +633,7 @@ discretise n p = density n $ (atom (id)) <*> p
 randcat :: [Pattern a] -> Pattern a
 randcat ps = spread' (<~) (discretise 1 $ ((%1) . fromIntegral) <$> irand (fromIntegral $ length ps)) (slowcat ps)
 
+{-
 toMIDI :: Pattern String -> Pattern Int
 toMIDI p = fromJust <$> (filterValues (isJust) (noteLookup <$> p))
   where
@@ -644,6 +646,18 @@ toMIDI p = fromJust <$> (filterValues (isJust) (noteLookup <$> p))
                      ]
     notes = ["c","cs","d","ds","e","f","fs","g","gs","a","as","b"]
     octaves = [0 .. 10]
+-}
+
+toMIDI :: Pattern String -> Pattern Int
+toMIDI p = fromJust <$> (filterValues (isJust) (noteLookup <$> p))
+  where
+    noteLookup [] = Nothing
+    noteLookup s | not (last s `elem` ['0' .. '9']) = noteLookup (s ++ "5")
+                 | not (isLetter (s !! 1)) = noteLookup((head s):'n':(tail s))
+                 | otherwise = parse s
+    parse x = (\a b c -> a+b+c) <$> pc x <*> sym x <*> Just(12*digitToInt (last x))
+    pc x = lookup (head x) [('c',0),('d',2),('e',4),('f',5),('g',7),('a',9),('b',11)]
+    sym x = lookup (init (tail x)) [("s",1),("f",-1),("n",0),("ss",2),("ff",-2)]
 
 tom = toMIDI
 

--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -633,6 +633,18 @@ discretise n p = density n $ (atom (id)) <*> p
 randcat :: [Pattern a] -> Pattern a
 randcat ps = spread' (<~) (discretise 1 $ ((%1) . fromIntegral) <$> irand (fromIntegral $ length ps)) (slowcat ps)
 
+-- | @toMIDI p@: converts a pattern of human-readable pitch names into
+-- MIDI pitch numbers. For example, @"cs4"@ will be rendered as @"49"@.
+-- Omitting the octave number will create a pitch in the fifth octave
+-- (@"cf"@ -> @"cf5"@). Pitches can be decorated using:
+--
+--    * s = Sharp, a half-step above (@"gs4"@)
+--    * f = Flat, a half-step below (@"gf4"@)
+--    * n = Natural, no decoration (@"g4" and "gn4"@ are equivalent)
+--    * ss = Double sharp, a whole step above (@"gss4"@)
+--    * ff = Double flat, a whole step below (@"gff4"@)
+--
+-- This function also has a shorter alias @tom@.
 toMIDI :: Pattern String -> Pattern Int
 toMIDI p = fromJust <$> (filterValues (isJust) (noteLookup <$> p))
   where
@@ -644,6 +656,7 @@ toMIDI p = fromJust <$> (filterValues (isJust) (noteLookup <$> p))
     pc x = lookup (head x) [('c',0),('d',2),('e',4),('f',5),('g',7),('a',9),('b',11)]
     sym x = lookup (init (tail x)) [("s",1),("f",-1),("n",0),("ss",2),("ff",-2)]
 
+-- | @tom p@: Alias for @toMIDI@.
 tom = toMIDI
 
 fit :: Int -> [a] -> Pattern Int -> Pattern a

--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -633,21 +633,6 @@ discretise n p = density n $ (atom (id)) <*> p
 randcat :: [Pattern a] -> Pattern a
 randcat ps = spread' (<~) (discretise 1 $ ((%1) . fromIntegral) <$> irand (fromIntegral $ length ps)) (slowcat ps)
 
-{-
-toMIDI :: Pattern String -> Pattern Int
-toMIDI p = fromJust <$> (filterValues (isJust) (noteLookup <$> p))
-  where
-    noteLookup [] = Nothing
-    noteLookup s | last s `elem` ['0' .. '9'] = elemIndex s names
-                 | otherwise = noteLookup (s ++ "5")
-    names = take 128 [(n ++ show o)
-                     | o <- octaves,
-                       n <- notes
-                     ]
-    notes = ["c","cs","d","ds","e","f","fs","g","gs","a","as","b"]
-    octaves = [0 .. 10]
--}
-
 toMIDI :: Pattern String -> Pattern Int
 toMIDI p = fromJust <$> (filterValues (isJust) (noteLookup <$> p))
   where


### PR DESCRIPTION
``toMIDI`` makes MIDI note patterns easier to read but being forced to use only sharps is not always musically convenient, so added flats, naturals, double sharps, and double flats:

```haskell
k1 $ note (toMIDI "[c,ef,gn5,bf5] dff6 gss6")
```

I am still learning Haskell so if my code can be improved please let me know. Maybe this function should be moved to [tidal-midi](https://github.com/tidalcycles/tidal-midi)?