### PR TITLE
Add source-repository section to cabal file

### DIFF
--- a/tidal.cabal
+++ b/tidal.cabal
@@ -17,6 +17,10 @@ Extra-source-files: README.md tidal.el doc/tidal.md
 
 Description: Tidal is a domain specific language for live coding pattern.
 
+source-repository head
+  type: git
+  location: https://github.com/tidalcycles/Tidal.git
+
 library
   Exposed-modules:     Sound.Tidal.Strategies
                        Sound.Tidal.Dirt


### PR DESCRIPTION
This enables `cabal get -s tidal` and also gives a clickable direct link from hackage to the repo.