### PR TITLE
parameters: loop can be a float

### DIFF
--- a/Sound/Tidal/Params.hs
+++ b/Sound/Tidal/Params.hs
@@ -150,7 +150,7 @@ Using `cut "0"` is effectively _no_ cutgroup.
 -}
 (lock, lock_p)                 = pF "lock" (Just 0)
 -- | loops the sample (from `begin` to `end`) the specified number of times.
-(loop, loop_p)                   = pI "loop" (Just 1)
+(loop, loop_p)                   = pF "loop" (Just 1)
 (lophat, lophat_p)               = pF "lophat" (Just 0)
 (lsnare, lsnare_p)               = pF "lsnare" (Just 0)
 -- | specifies the sample variation to be used


### PR DESCRIPTION
There is no reason why the loop parameter shouldn’t be a fraction, and
also between 0…1 — like this we get a legato parameter for free.