### PR TITLE
Replace random number generator - from mersenne-random-pure64 to tf-random

### DIFF
--- a/tidal.cabal
+++ b/tidal.cabal
@@ -32,4 +32,4 @@ library
                        Sound.Tidal.Params
                        Sound.Tidal.Transition
 
-  Build-depends: base < 5, process, parsec, hosc > 0.13, hashable, colour, containers, time, websockets > 0.8, text, mtl >=2.1, transformers, mersenne-random-pure64,binary, bytestring, hmt
+  Build-depends: base < 5, process, parsec, hosc > 0.13, hashable, colour, containers, time, websockets > 0.8, text, mtl >=2.1, transformers, tf-random,binary, bytestring, hmt


### PR DESCRIPTION
Update - please hold off this pull request for the time being, see message below.

--------------
Hi Alex and all

Here is a pull request to change the random number generator to tf-random which is easier to compile on Windows now that the Platform no longer ships old-time (which the previous random generator mersenne-random-pure64 depends on).

The patch replicates the function _randomDouble_ (from mersenne) as tf-random only generates Word32's - via the function _next_ in the module TF.Gen.

I've tested that the new implementation of _randomDouble_ generates a comparable distribution of numbers between 0 and 1.0 to the implementation in mersenne. A zip of the test functions is attached.

Please note - both mersenne and tf-random are pseudo random number generators - they will generate the same sequences of random numbers if run with the same initial seed. Obviously the sequences mersenne generates are different to those generated by tf-random.

[test.zip](https://github.com/tidalcycles/Tidal/files/423638/test.zip)


