### PR TITLE
[fix] force compatible mersenne-random version

### DIFF
--- a/tidal.cabal
+++ b/tidal.cabal
@@ -32,4 +32,4 @@ library
                        Sound.Tidal.Params
                        Sound.Tidal.Transition
 
-  Build-depends: base < 5, process, parsec, hosc > 0.13, hashable, colour, containers, time, websockets > 0.8, text, mtl >=2.1, transformers, mersenne-random-pure64,binary, bytestring, hmt
+  Build-depends: base < 5, process, parsec, hosc > 0.13, hashable, colour, containers, time, websockets > 0.8, text, mtl >=2.1, transformers, mersenne-random-pure64 < 0.2.1.0, binary, bytestring, hmt


### PR DESCRIPTION
make sure new users with ghc below 7.8 can still install tidal, as mersenne random pure package (0.2.1.0) will break.

this might need to be accompained by a version bump to 0.8.1 and published to hackage