### PR TITLE
0.9 extrautils

### DIFF
--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -340,6 +340,10 @@ every :: Int -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
 every 0 _ p = p
 every n f p = when ((== 0) . (`mod` n)) f p
 
+-- | @every n o f'@ is like @every n f@ with an offset of @o@ cycles
+every' :: Int -> Int -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a
+every' n o f = when ((== o) . (`mod` n)) f
+
 -- | @foldEvery ns f p@ applies the function @f@ to @p@, and is applied for
 -- each cycle in @ns@.
 foldEvery :: [Int] -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a

--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -1170,3 +1170,12 @@ toScale' o s p = (+) <$> fmap (s!!) notep <*> fmap (o*) octp
 
 toScale::[Int] -> Pattern Int -> Pattern Int
 toScale = toScale' 12
+
+{- | `swingBy x n` divides a cycle into `n` slices and delays the notes in
+the second half of each slice by `x` fraction of a slice . `swing` is an alias
+for `swingBy (1%3)`
+-}
+swingBy::Time -> Time -> Pattern a -> Pattern a 
+swingBy x n = inside n (within (0.5,1) (x ~>))
+
+swing = swingBy (1%3)

--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -700,6 +700,13 @@ almostAlways = sometimesBy 0.9
 never = flip const
 always = id
 
+{- | `somecyclesBy` is a cycle-by-cycle version of sometimesBy, and has a
+`somecycles = somecyclesBy 0.5` alias -}
+somecyclesBy x = when (test x)
+  where test x c = (timeToRand $ fromIntegral c) < x
+
+somecycles = somecyclesBy 0.5
+
 {- | `degrade` randomly removes events from a pattern 50% of the time:
 
 @

--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -1156,3 +1156,17 @@ seqPLoop :: [(Time, Time, Pattern a)] -> Pattern a
 seqPLoop ps = timeLoop (maxT - minT) $ minT <~ seqP ps
   where minT = minimum $ map fst' ps
         maxT = maximum $ map snd' ps
+
+{- | `toScale` lets you turn a pattern of notes within a scale (expressed as a
+list) to note numbers.  For example `toScale [0, 4, 7] "0 1 2 3"` will turn
+into the pattern `"0 4 7 12"`.  It assumes your scale fits within an octave,
+to change this use `toScale' size`.  Example:
+`toscale' 24 [0,4,7,10,14,17] (run 8)` turns into `"0 4 7 10 14 17 24 28"`
+-}
+toScale'::Int -> [Int] -> Pattern Int -> Pattern Int
+toScale' o s p = (+) <$> fmap (s!!) notep <*> fmap (o*) octp
+  where notep = fmap (`mod` (length s)) p
+        octp  = fmap (`div` (length s)) p
+
+toScale::[Int] -> Pattern Int -> Pattern Int
+toScale = toScale' 12

--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -704,7 +704,7 @@ almostAlways = sometimesBy 0.9
 never = flip const
 always = id
 
-{- | `somecyclesBy` is a cycle-by-cycle version of sometimesBy, and has a
+{- | @somecyclesBy@ is a cycle-by-cycle version of @sometimesBy@, and has a
 `somecycles = somecyclesBy 0.5` alias -}
 somecyclesBy x = when (test x)
   where test x c = (timeToRand $ fromIntegral c) < x
@@ -1157,7 +1157,7 @@ seqPLoop ps = timeLoop (maxT - minT) $ minT <~ seqP ps
   where minT = minimum $ map fst' ps
         maxT = maximum $ map snd' ps
 
-{- | `toScale` lets you turn a pattern of notes within a scale (expressed as a
+{- | @toScale@ lets you turn a pattern of notes within a scale (expressed as a
 list) to note numbers.  For example `toScale [0, 4, 7] "0 1 2 3"` will turn
 into the pattern `"0 4 7 12"`.  It assumes your scale fits within an octave,
 to change this use `toScale' size`.  Example:
@@ -1172,7 +1172,7 @@ toScale::[Int] -> Pattern Int -> Pattern Int
 toScale = toScale' 12
 
 {- | `swingBy x n` divides a cycle into `n` slices and delays the notes in
-the second half of each slice by `x` fraction of a slice . `swing` is an alias
+the second half of each slice by `x` fraction of a slice . @swing@ is an alias
 for `swingBy (1%3)`
 -}
 swingBy::Time -> Time -> Pattern a -> Pattern a 

--- a/Sound/Tidal/Strategies.hs
+++ b/Sound/Tidal/Strategies.hs
@@ -198,6 +198,11 @@ d1 $ jux (iter 4) $ sound "arpy arpy:2*2"
 scale :: (Functor f, Num b) => b -> b -> f b -> f b
 scale from to p = ((+ from) . (* (to-from))) <$> p
 
+{- | `scalex` is an exponential version of `scale`, good for using with
+frequencies.  Do *not* use negative numbers or zero as arguments! -}
+scalex :: (Functor f, Floating b) => b -> b -> f b -> f b
+scalex from to p = exp <$> scale (log from) (log to) p
+
 {- | `chop` granualizes every sample in place as it is played, turning a pattern of samples into a pattern of sample parts. Use an integer value to specify how many granules each sample is chopped into:
 
 @

--- a/Sound/Tidal/Stream.hs
+++ b/Sound/Tidal/Stream.hs
@@ -218,6 +218,7 @@ infixl 1 |/|
 (|/|) :: ParamPattern -> ParamPattern -> ParamPattern
 (|/|) = mergeNumWith (div) (/)
 
+{- | These are shorthand for merging lists of patterns with @#@, @|*|@, @|+|@,
 or @|/|@.  Sometimes this saves a little typing and can improve readability
 when passing things into other functions.  As an example, instead of writing
 @

--- a/Sound/Tidal/Stream.hs
+++ b/Sound/Tidal/Stream.hs
@@ -218,6 +218,11 @@ infixl 1 |/|
 (|/|) :: ParamPattern -> ParamPattern -> ParamPattern
 (|/|) = mergeNumWith (div) (/)
 
+(###) = foldl (#)
+(***) = foldl (|*|)
+(+++) = foldl (|+|)
+(///) = foldl (|/|)
+
 setter :: MVar (a, [a]) -> a -> IO ()
 setter ds p = do ps <- takeMVar ds
                  putMVar ds $ (p, p:snd ps)

--- a/Sound/Tidal/Stream.hs
+++ b/Sound/Tidal/Stream.hs
@@ -218,6 +218,16 @@ infixl 1 |/|
 (|/|) :: ParamPattern -> ParamPattern -> ParamPattern
 (|/|) = mergeNumWith (div) (/)
 
+or @|/|@.  Sometimes this saves a little typing and can improve readability
+when passing things into other functions.  As an example, instead of writing
+@
+d1 $ sometimes ((|*| speed "2") . (|*| cutoff "2") . (|*| shape "1.5")) $ sound "arpy*4" # cutoff "350" # shape "0.3"
+@
+you can write
+@
+d1 $ sometimes (*** [speed "2", cutoff "2", shape "1.5"]) $ sound "arpy*4" ### [cutoff "350", shape "0.3"]
+@
+-}
 (###) = foldl (#)
 (***) = foldl (|*|)
 (+++) = foldl (|+|)


### PR DESCRIPTION
This is a combination of the small utility functions that I've been using the most, some of which have been picked up by other people.  The individual commits have short descriptions (and I've tried to include comments in the code that can be auto-harvested), but here's a short index:

  * swing, swingBy - alter pattern timing
  * toScale - select from notes in a scale
  * every' - every with an offset
  * scalex - exponential version of scale
  * somecycles, somecyclesBy - like sometimes, but per cycle rather than per event
  * (***) (+++) (###) - pattern merging operators on lists, can save some typing