### PR TITLE
drum now uses `midinote` instead of `n`

### DIFF
--- a/Sound/Tidal/Params.hs
+++ b/Sound/Tidal/Params.hs
@@ -264,7 +264,7 @@ voi  = voice
 note = n
 midinote = n . ((subtract 60) <$>)
 
-drum = n . (drumN <$>)
+drum = midinote . (drumN <$>)
 
 drumN :: String -> Int
 drumN "bd"  = 36


### PR DESCRIPTION
Small fix for (percussion) midi devices