### PR TITLE
`drum` uses `midinote` instead of `note`

### DIFF
--- a/Sound/Tidal/Params.hs
+++ b/Sound/Tidal/Params.hs
@@ -298,7 +298,7 @@ note = n
 midinote = n . ((subtract 60) <$>)
 
 drum :: Pattern String -> ParamPattern
-drum = n . (drumN <$>)
+drum = midinote . (drumN <$>)
 
 drumN :: String -> Int
 drumN "bd"  = 36


### PR DESCRIPTION
Fixes an issue with Volca Beats devices

Same thing as before except this time goes for the *current development* branch