### PR TITLE
Fix issue with toScale.

### DIFF
--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -1457,9 +1457,9 @@ to change this use `toScale' size`.  Example:
 -}
 toScale' :: Int -> [Int] -> Pattern Int -> Pattern Int
 toScale' o s = fmap noteInScale
-  where note x = x `mod` length scale
-        octave x = x `div` length scale
-        noteInScale x = (scale !!! note x) + o * octave x
+  where note x = x `mod` length s
+        octave x = x `div` length s
+        noteInScale x = (s !!! note x) + o * octave x
 
 toScale :: [Int] -> Pattern Int -> Pattern Int
 toScale = toScale' 12

--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -1451,16 +1451,17 @@ seqPLoop ps = timeLoop (maxT - minT) $ minT `rotL` seqP ps
 
 {- | @toScale@ lets you turn a pattern of notes within a scale (expressed as a
 list) to note numbers.  For example `toScale [0, 4, 7] "0 1 2 3"` will turn
-into the pattern `"0 4 7 12"`.  It assumes your scale fits within an octave,
+into the pattern `"0 4 7 12"`.  It assumes your scale fits within an octave;
 to change this use `toScale' size`.  Example:
-`toscale' 24 [0,4,7,10,14,17] (run 8)` turns into `"0 4 7 10 14 17 24 28"`
+`toScale' 24 [0,4,7,10,14,17] (run 8)` turns into `"0 4 7 10 14 17 24 28"`
 -}
-toScale'::Int -> [Int] -> Pattern Int -> Pattern Int
-toScale' o s p = (+) <$> fmap (s!!) notep <*> fmap (o*) octp
-  where notep = fmap (`mod` (length s)) p
-        octp  = fmap (`div` (length s)) p
+toScale' :: Int -> [Int] -> Pattern Int -> Pattern Int
+toScale' o s = fmap noteInScale
+  where note x = x `mod` length scale
+        octave x = x `div` length scale
+        noteInScale x = (scale !!! note x) + o * octave x
 
-toScale::[Int] -> Pattern Int -> Pattern Int
+toScale :: [Int] -> Pattern Int -> Pattern Int
 toScale = toScale' 12
 
 {- | `swingBy x n` divides a cycle into `n` slices and delays the notes in

--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -1457,9 +1457,8 @@ to change this use `toScale' size`.  Example:
 -}
 toScale' :: Int -> [Int] -> Pattern Int -> Pattern Int
 toScale' o s = fmap noteInScale
-  where note x = x `mod` length s
-        octave x = x `div` length s
-        noteInScale x = (s !!! note x) + o * octave x
+  where octave x = x `div` length s
+        noteInScale x = (s !!! x) + o * octave x
 
 toScale :: [Int] -> Pattern Int -> Pattern Int
 toScale = toScale' 12


### PR DESCRIPTION
It seemed to be behaving strangely with patterns of overlapping
events, or patterns containing events that spanned multiple cycles.

This version fixes that by mapping over the pattern just once,
rather than doing it once for the note value and once for the octave
and then combining the two.

Also touch up documentation.