### PR TITLE
Add two Bjorklund functions

### DIFF
--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -1129,9 +1129,16 @@ e n k p = (flip const) <$> (filterValues (== True) $ listToPat $ bjorklund (n,k)
 e' :: Int -> Int -> Pattern a -> Pattern a
 e' n k p = fastcat $ map (\x -> if x then p else silence) (bjorklund (n,k))
 
+{- | `einv` fills in the blanks left by `e`
+ -
+ @e 3 8 "x"@ -> @"x ~ ~ x ~ ~ x ~"@
+
+ @einv 3 8 "x"@ -> @"~ x x ~ x x ~ x"@
+-}
 einv :: Int -> Int -> Pattern a -> Pattern a
 einv n k p = (flip const) <$> (filterValues (== False) $ listToPat $ bjorklund (n,k)) <*> p
 
+{- | `efull n k pa pb` stacks @e n k pa@ with @einv n k pb@ -}
 efull :: Int -> Int -> Pattern a -> Pattern a -> Pattern a
 efull n k pa pb = stack [ e n k pa, einv n k pb ]
 

--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -1129,6 +1129,11 @@ e n k p = (flip const) <$> (filterValues (== True) $ listToPat $ bjorklund (n,k)
 e' :: Int -> Int -> Pattern a -> Pattern a
 e' n k p = fastcat $ map (\x -> if x then p else silence) (bjorklund (n,k))
 
+einv :: Int -> Int -> Pattern a -> Pattern a
+einv n k p = (flip const) <$> (filterValues (== False) $ listToPat $ bjorklund (n,k)) <*> p
+
+efull :: Int -> Int -> Pattern a -> Pattern a -> Pattern a
+efull n k pa pb = stack [ e n k pa, einv n k pb ]
 
 index :: Real b => b -> Pattern b -> Pattern c -> Pattern c
 index sz indexpat pat = spread' (zoom' $ toRational sz) (toRational . (*(1-sz)) <$> indexpat) pat


### PR DESCRIPTION
Adds `einv` which fills the "blanks" left by `e`:

`e 3 8 "x"` -> `"x ~ ~ x ~ ~ x ~"`
`einv 3 8 "x"` -> `"~ x x ~ x x ~ x"`

And `efull n k pa pb` which takes two patterns, and stacks `e n k` on
the first with `einv n k` on the second.

`efull 3 8 "2" "1"` -> `"2 1 1 2 1 1 2 1"`