### PR TITLE
Stack build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 cabal
 *.o
 *.hi
+.stack-work

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,4 @@ extra-deps:
 - applicative-numbers-0.1.3
 - binary-0.7.5.0
 - hosc-0.15
-resolver: lts-2.14
+resolver: lts-9.6

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-- applicative-numbers-0.1.3
-- binary-0.7.5.0
-- hosc-0.15
 resolver: lts-9.6


### PR DESCRIPTION
Updating stack build settings

* change to newest lts resolver (builds with ghc 8.0.2)
* ignore .stack-work folder
* remove extra-deps packages from stack config (don't seem to be necessary)

all tests passing, building and running locally on OSX