### PR TITLE
Add lindenmayerI

### DIFF
--- a/Sound/Tidal/Pattern.hs
+++ b/Sound/Tidal/Pattern.hs
@@ -15,7 +15,7 @@ import Data.Ratio
 import Data.Typeable
 import Data.Function
 import System.Random.Mersenne.Pure64
--- import Data.Char
+import Data.Char (digitToInt)
 import qualified Data.Text as T
 
 import Sound.Tidal.Time
@@ -1409,6 +1409,11 @@ lindenmayer _ _ [] = []
 lindenmayer 1 r (c:cs) = (fromMaybe [c] $ lookup c $ parseLMRule' r)
                          ++ (lindenmayer 1 r cs)
 lindenmayer n r s = iterate (lindenmayer 1 r) s !! n
+
+{- | @lindenmayerI@ converts the resulting string into a a list of integers
+with @fromIntegral@ applied (so they can be used seamlessly where floats or
+rationals are required) -}
+lindenmayerI n r s = fmap fromIntegral $ fmap digitToInt $ lindenmayer n r s
 
 -- support for fit'
 unwrap' :: Pattern (Pattern a) -> Pattern a


### PR DESCRIPTION
Adds a version of the `lindenmayer` function that converts the
resulting string into a list of numbers.  This makes using the string
as a pattern of note numbers or parameter values much easier.