### PR TITLE
Generalise `rand` to match other continuous functions

### DIFF
--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -71,9 +71,8 @@ and with the juxed version shifted backwards for 1024 cycles:
 jux (# ((1024 <~) $ gain rand)) $ sound "sn sn ~ sn" # gain rand
 @
 -}
-
-rand :: Pattern Double
-rand = Pattern Analog (\(State a _) -> [((a, a), timeToRand $ mid a)])
+rand :: Fractional a => Pattern a
+rand = Pattern Analog (\(State a _) -> [((a, a), realToFrac $ timeToRand $ mid a)])
 
 {- | Just like `rand` but for whole numbers, `irand n` generates a pattern of (pseudo-) random whole numbers between `0` to `n-1` inclusive. Notably used to pick a random
 samples from a folder:

--- a/test/Sound/Tidal/UITest.hs
+++ b/test/Sound/Tidal/UITest.hs
@@ -71,3 +71,14 @@ run =
           expectedResult = ps "cp hh bd*2"
           in
             compareP overTimeSpan testMe expectedResult
+
+    describe "rand" $ do
+      it "generates a (pseudo-)random number between zero & one" $ do
+        it "at the start of a cycle" $
+          (queryArc rand (0, 0)) `shouldBe` [(((0, 0), (0, 0)), 0.5000844 :: Float)]
+        it "at 1/4 of a cycle" $
+          (queryArc rand (0.25, 0.25)) `shouldBe`
+            [(((0.25, 0.25), (0.25, 0.25)), 0.8587171 :: Float)]
+        it "at 3/4 of a cycle" $
+          (queryArc rand (0.75, 0.75)) `shouldBe`
+            [(((0.75, 0.75), (0.75, 0.75)), 0.7277789 :: Float)]


### PR DESCRIPTION
Fixes #386