### PR TITLE
Do /127 conversion in cF for incoming Int messages

### DIFF
--- a/src/Sound/Tidal/Control.hs
+++ b/src/Sound/Tidal/Control.hs
@@ -357,7 +357,7 @@ _cX f ds s = Pattern Analog $
 
 _cF :: [Double] -> String -> Pattern Double
 _cF = _cX f
-  where f a (VI v) = [((a,a),fromIntegral v)]
+  where f a (VI v) = [((a,a),(fromIntegral v)/127.0)]
         f a (VF v) = [((a,a),v)]
         f a (VS v) = maybe [] (\v' -> [((a,a),v')]) (readMaybe v)
 


### PR DESCRIPTION
If the incoming OSC value is integer format, and Tidal is converting it to a Pattern Double, then it's likely a MIDI value >float conversion.  So dividing by 127 here is more convenient for the end user - with this change both `cI` and `cF` will produce reasonable results from incoming Integer messages.