### PR TITLE
Value type

### DIFF
--- a/src/Sound/Tidal/Control.hs
+++ b/src/Sound/Tidal/Control.hs
@@ -357,7 +357,7 @@ _cX f ds s = Pattern Analog $
 
 _cF :: [Double] -> String -> Pattern Double
 _cF = _cX f
-  where f a (VI v) = [((a,a),(fromIntegral v)/127.0)]
+  where f a (VI v) = [((a,a),fromIntegral v)]
         f a (VF v) = [((a,a),v)]
         f a (VS v) = maybe [] (\v' -> [((a,a),v')]) (readMaybe v)
 

--- a/src/Sound/Tidal/Control.hs
+++ b/src/Sound/Tidal/Control.hs
@@ -357,7 +357,7 @@ _cX f ds s = Pattern Analog $
 
 _cF :: [Double] -> String -> Pattern Double
 _cF = _cX f
-  where f a (VI v) = [((a,a),fromIntegral v)]
+  where f a (VI v) = [((a,a),(fromIntegral v)/127.0)]
         f a (VF v) = [((a,a),v)]
         f a (VS v) = maybe [] (\v' -> [((a,a),v')]) (readMaybe v)
 

--- a/src/Sound/Tidal/Control.hs
+++ b/src/Sound/Tidal/Control.hs
@@ -345,21 +345,15 @@ _stut' :: (Num n, Ord n) => n -> Time -> (Pattern a -> Pattern a) -> Pattern a -
 _stut' count steptime f p | count <= 0 = p
                           | otherwise = overlay (f (steptime `rotR` _stut' (count-1) steptime f p)) p
 
-_cX :: (Arc -> Value -> [Event a]) -> [a] -> String -> Pattern a
-_cX f ds s = Pattern Analog $
-               \(State a m) -> maybe (map (\d -> ((a,a),d)) ds) (f a) $ Map.lookup s m
-
-_cI :: [Int] -> String -> Pattern Int
-_cI = _cX f
+cI :: String -> Pattern Int
+cI s = Pattern Analog $ \(State a m) -> maybe [] (f a) $ Map.lookup s m
   where f a (VI v) = [((a,a),v)]
         f a (VF v) = [((a,a),floor v)]
         f a (VS v) = maybe [] (\v' -> [((a,a),v')]) (readMaybe v)
-cI :: Int -> String -> Pattern Int
-cI d = _cI [d]
-cI1 :: String -> Pattern Int
-cI1 = _cI [1]
-cI_ :: String -> Pattern Int
-cI_ = _cI []
+
+_cX :: (Arc -> Value -> [Event a]) -> [a] -> String -> Pattern a
+_cX f ds s = Pattern Analog $
+               \(State a m) -> maybe (map (\d -> ((a,a),d)) ds) (f a) $ Map.lookup s m
 
 _cF :: [Double] -> String -> Pattern Double
 _cF = _cX f

--- a/src/Sound/Tidal/Control.hs
+++ b/src/Sound/Tidal/Control.hs
@@ -345,15 +345,21 @@ _stut' :: (Num n, Ord n) => n -> Time -> (Pattern a -> Pattern a) -> Pattern a -
 _stut' count steptime f p | count <= 0 = p
                           | otherwise = overlay (f (steptime `rotR` _stut' (count-1) steptime f p)) p
 
-cI :: String -> Pattern Int
-cI s = Pattern Analog $ \(State a m) -> maybe [] (f a) $ Map.lookup s m
-  where f a (VI v) = [((a,a),v)]
-        f a (VF v) = [((a,a),floor v)]
-        f a (VS v) = maybe [] (\v' -> [((a,a),v')]) (readMaybe v)
-
 _cX :: (Arc -> Value -> [Event a]) -> [a] -> String -> Pattern a
 _cX f ds s = Pattern Analog $
                \(State a m) -> maybe (map (\d -> ((a,a),d)) ds) (f a) $ Map.lookup s m
+
+_cI :: [Int] -> String -> Pattern Int
+_cI = _cX f
+  where f a (VI v) = [((a,a),v)]
+        f a (VF v) = [((a,a),floor v)]
+        f a (VS v) = maybe [] (\v' -> [((a,a),v')]) (readMaybe v)
+cI :: Int -> String -> Pattern Int
+cI d = _cI [d]
+cI1 :: String -> Pattern Int
+cI1 = _cI [1]
+cI_ :: String -> Pattern Int
+cI_ = _cI []
 
 _cF :: [Double] -> String -> Pattern Double
 _cF = _cX f

--- a/src/Sound/Tidal/Core.hs
+++ b/src/Sound/Tidal/Core.hs
@@ -393,7 +393,7 @@ whenT test f p = splitQueries $ p {query = apply}
 
 -- | like filterValues but for ControlPatterns
 filterControlValues :: (ValueType a) => String -> (a -> Bool) -> ControlPattern -> ControlPattern
-filterControlValues ctl f = filterValues (safeTest . (Map.!?ctl)) where
+filterControlValues ctl f = filterValues (safeTest . (Map.lookup ctl)) where
   safeTest (Just a) = (f . fromV) a
   safeTest (Nothing) = False
 

--- a/src/Sound/Tidal/Core.hs
+++ b/src/Sound/Tidal/Core.hs
@@ -390,3 +390,24 @@ whenT test f p = splitQueries $ p {query = apply}
 --eoff :: Int -> Int -> Integer -> Pattern a -> Pattern a
 --eoff n k s p = ((s%(fromIntegral k)) `rotL`) (_e n k p)
    -- TPat_ShiftL (s%(fromIntegral k)) (TPat_E n k p)
+
+-- | like filterValues but for ControlPatterns
+filterControlValues :: (ValueType a) => String -> (a -> Bool) -> ControlPattern -> ControlPattern
+filterControlValues ctl f = filterValues (safeTest . (Map.!?ctl)) where
+  safeTest (Just a) = (f . fromV) a
+  safeTest (Nothing) = False
+
+withControlValues :: (ValueType a, Eq a) => String -> [a] -> (ControlPattern -> ControlPattern) -> ControlPattern -> ControlPattern
+withControlValues ctl vs f p = stack [
+  f $ filterControlValues ctl (flip elem vs) p,
+  filterControlValues ctl (flip notElem vs) p
+  ]
+
+withControlValue ctl v = withControlValues ctl [v]
+
+withControlRange :: (ValueType a, Ord a) => String -> (a,a) -> (ControlPattern -> ControlPattern) -> ControlPattern -> ControlPattern
+withControlRange ctl (va,vb) f p = stack [
+  f $ filterControlValues ctl (\x -> (x < vb) && (x >= va)) p,
+  filterControlValues ctl (\x -> (x >= vb) || (x < va)) p
+  ]
+

--- a/src/Sound/Tidal/Pattern.hs
+++ b/src/Sound/Tidal/Pattern.hs
@@ -55,6 +55,8 @@ data Value = VS { svalue :: String }
 type ControlMap = Map.Map String Value
 type ControlPattern = Pattern ControlMap
 
+class ValueType a where
+  fromV :: Value -> a
 
 ------------------------------------------------------------------------
 -- * Instances
@@ -310,6 +312,15 @@ instance Num (ControlMap) where
 instance Fractional ControlMap where
   recip        = fmap (applyFIS recip id id)
   fromRational = Map.singleton "speed" . VF . fromRational
+
+instance ValueType String where
+  fromV = svalue
+
+instance ValueType Int where
+  fromV = ivalue
+
+instance ValueType Double where
+  fromV = fvalue
 
 
 instance {-# OVERLAPPING #-} Show Arc where


### PR DESCRIPTION
Again, sorry for the reverts in the history, trying to do too many PRs at once...

This implements a `filterControlValues` function that works much like `filterValues` but operates on ControlPatterns and makes it a bit easier to pick out specific values.  For this to work on generic types it is unfortunately necessary to resurrect the ParamType class (now called ValueType), so there's a little extra bolierplate in Pattern.hs

There are also `withControlValue`, `withControlValues`, and `withControlRange` functions, which generalize the functionality of `modNote` mentioned in #345