### PR TITLE
Fix setcps via streamOnce

### DIFF
--- a/src/Sound/Tidal/Stream.hs
+++ b/src/Sound/Tidal/Stream.hs
@@ -91,6 +91,25 @@ toDatum (VS x) = O.string x
 toData :: Event ControlMap -> [O.Datum]
 toData e = concatMap (\(n,v) -> [O.string n, toDatum v]) $ Map.toList $ eventValue e
 
+toMessage :: OSCTarget -> T.Tempo -> Event (Map.Map String Value) -> O.Message
+toMessage target tempo e = O.Message (oPath target) $ oPreamble target ++ toData (addCps e)
+  where on e = sched tempo $ fst $ eventWhole e
+        off e = sched tempo $ snd $ eventWhole e
+        delta e = (off e) - (on e)
+        -- If there is already cps in the event, the union will preserve that.
+        addCps e = (\v -> (Map.union v $ Map.fromList [("cps", (VF $ T.cps tempo)),
+                                                       ("delta", VF (delta e)),
+                                                       ("cycle", VF (fromRational $ fst $ eventWhole e))
+                                                       ])) <$> e
+
+doCps :: MVar T.Tempo -> (Double, Maybe Value) -> IO ()
+doCps tempoMV (d, Just (VF cps)) = do _ <- forkIO $ do threadDelay $ floor $ d * 1000000
+                                                       -- hack to stop things from stopping
+                                                       _ <- T.setCps tempoMV (max 0.1 cps)
+                                                       return ()
+                                      return ()
+doCps _ _ = return ()
+
 onTick :: MVar ControlMap -> MVar ControlPattern -> OSCTarget -> O.UDP -> MVar T.Tempo -> T.State -> IO ()
 onTick cMapMV pMV target u tempoMV st =
   do p <- readMVar pMV
@@ -99,30 +118,14 @@ onTick cMapMV pMV target u tempoMV st =
      now <- O.time
      let es = filter eventHasOnset $ query p (State {arc = T.nowArc st, controls = cMap})
          on e = sched tempo $ fst $ eventWhole e
-         off e = sched tempo $ snd $ eventWhole e
-         delta e = (off e) - (on e)
-         messages = map (\e -> (on e, toMessage e)) es
+         messages = map (\e -> (on e, toMessage target tempo e)) es
          cpsChanges = map (\e -> (on e - now, Map.lookup "cps" $ eventValue e)) es
-         cpsNow = T.cps tempo
-         -- If there is already cps in the event, the union will preserve that.
-         addCps e = (\v -> (Map.union v $ Map.fromList [("cps", (VF cpsNow)),
-                                                        ("delta", VF (delta e)),
-                                                        ("cycle", VF (fromRational $ fst $ eventWhole e))
-                                                       ]
-                           )) <$> e
-         toMessage e = O.Message (oPath target) $ oPreamble target ++ toData (addCps e)
      E.catch (mapM_ (send target u) messages)
        (\(_ ::E.SomeException)
         -> putStrLn $ "Failed to send. Is the target (probably superdirt) running?")
                 -- ++ show (msg :: E.SomeException))
-     mapM_ doCps cpsChanges
+     mapM_ (doCps tempoMV) cpsChanges
      return ()
-  where doCps (d, Just (VF cps)) = do _ <- forkIO $ do threadDelay $ floor $ d * 1000000
-                                                       -- hack to stop things from stopping
-                                                       _ <- T.setCps tempoMV (max 0.1 cps)
-                                                       return ()
-                                      return ()
-        doCps _ = return ()
 
 send :: O.Transport t => OSCTarget -> t -> (Double, O.Message) -> IO ()
 send target u (time, m) = O.sendOSC u $ O.Bundle (time + (oLatency target)) [m]
@@ -194,29 +197,14 @@ streamOnce st asap p
                                                )
            at e = sched fakeTempo $ fst $ eventWhole e
            on e = sched tempo $ fst $ eventWhole e
-           off e = sched tempo $ snd $ eventWhole e
-           delta e = (off e) - (on e)
-           cpsNow = T.cps tempo
            cpsChanges = map (\e -> (on e - now, Map.lookup "cps" $ eventValue e)) es
-           -- If there is already cps in the event, the union will preserve that.
-           addCps e = (\v -> (Map.union v $ Map.fromList [("cps", (VF $ cpsNow)),
-                                                        ("delta", VF (delta e)),
-                                                        ("cycle", VF (fromRational $ fst $ eventWhole e))
-                                                        ])) <$> e
-           messages = map (\e -> (at e, toMessage e)) es
-           toMessage e = O.Message (oPath target) $ oPreamble target ++ toData (addCps e)
+           messages = map (\e -> (at e, toMessage target fakeTempo e)) es
        E.catch (mapM_ (send target (sUDP st)) messages)
          (\(msg ::E.SomeException)
           -> putStrLn $ "Failed to send. Is the target (probably superdirt) running? " ++ show (msg :: E.SomeException))
-       mapM_ doCps cpsChanges
+       mapM_ (doCps $ sTempoMV st) cpsChanges
        return ()
-    where doCps (d, Just (VF cps)) = do _ <- forkIO $ do threadDelay $ floor $ d * 1000000
-                                                         -- hack to stop things from stopping
-                                                         _ <- T.setCps (sTempoMV st) (max 0.1 cps)
-                                                         return ()
-                                        return ()
-          doCps _ = return ()
-                    
+
 withPatId :: Stream -> PatId -> (PlayState -> PlayState) -> IO ()
 withPatId s k f = withPatIds s [k] f
 
@@ -249,7 +237,7 @@ calcOutput s = do pMap <- readMVar $ sPMapMV s
           stack $ map pattern $ filter (\pState -> if hasSolo pMap
                                                    then solo pState
                                                    else not (mute pState)
-                                       ) (Map.elems pMap)  
+                                       ) (Map.elems pMap)
 
 startTidal :: OSCTarget -> Config -> IO Stream
 startTidal target c = do cMapMV <- newMVar (Map.empty :: ControlMap)


### PR DESCRIPTION
This adds code to `streamOnce` to properly set the cps when using the `setcps` function in BootTidal.hs.  Also factored out the `toMessage` and `doCps` functions which were common to both `onTick` and `streamOnce`.