### PR TITLE
Simplify travis cabal testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,12 @@ before_cache:
 
 matrix:
   include:
-    - env: BUILD=cabal GHCVER=8.6.2
-      compiler: "ghc-8.6.2"
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.2], sources: [hvr-ghc]}}
+    - env: BUILD=cabal-old GHCVER=8.6.3
+      compiler: "ghc-8.6.3"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc]}}
+    - env: BUILD=cabal GHCVER=8.6.3
+      compiler: "ghc-8.6.3"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.3], sources: [hvr-ghc]}}
     - env: BUILD=cabal GHCVER=8.4.4
       compiler: "ghc-8.4.4"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
@@ -49,19 +52,22 @@ matrix:
 
   allow_failures:
     - env: BUILD=stack ARGS="--resolver nightly"
+    - env: BUILD=cabal GHCVER=8.6.3
 
 before_install:
 - |
   case "$BUILD" in
     cabal)
-      HC=${CC}
-      HCPKG=${HC/ghc/ghc-pkg}
       unset CC
-      ROOTDIR=$(pwd)
-      mkdir -p $HOME/.local/bin
-      "PATH=/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$HOME/local/bin:$PATH"
-      HCNUMVER=$(( $(${HC} --numeric-version|sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 * 10000 + \2 * 100 + \3/') ))
-      echo $HCNUMVER
+      export PATH=/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$PATH
+      cabal new-update
+      cabal --version
+      ;;
+    cabal-old)
+      unset CC
+      export PATH=/opt/ghc/bin:/opt/ghc-ppa-tools/bin:$PATH
+      cabal update
+      cabal --version
       ;;
     stack)
       PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
@@ -83,32 +89,10 @@ install:
 - |
   case "$BUILD" in
     cabal)
-      cabal --version
-      echo "$(${HC} --version) [$(${HC} --print-project-git-commit-id 2> /dev/null || echo '?')]"
-      BENCH=${BENCH---enable-benchmarks}
-      TEST=${TEST---enable-tests}
-      HADDOCK=${HADDOCK-true}
-      UNCONSTRAINED=${UNCONSTRAINED-true}
-      NOINSTALLEDCONSTRAINTS=${NOINSTALLEDCONSTRAINTS-false}
-      GHCHEAD=${GHCHEAD-false}
-      travis_retry cabal update -v
-      "sed -i.bak 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config"
-      rm -fv cabal.project cabal.project.local
-      grep -Ev -- '^\s*--' ${HOME}/.cabal/config | grep -Ev '^\s*$'
-      "printf 'packages: \".\"\\n' > cabal.project"
-      "printf 'write-ghc-environment-files: always\\n' >> cabal.project"
-      touch cabal.project.local
-      "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- tidal | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
-      cat cabal.project || true
-      cat cabal.project.local || true
-      if [ -f "./configure.ac" ]; then
-      (cd "." && autoreconf -i);
-      fi
-      rm -f cabal.project.freeze
-      cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
-      cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
-      rm -rf .ghc.environment.* "."/dist
-      DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
+      cabal install --only-dependencies --enable-test
+      ;;
+    cabal-old)
+      cabal install --only-dependencies --enable-tests
       ;;
     stack)
       stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
@@ -119,31 +103,12 @@ script:
 - |
   case "$BUILD" in
     cabal)
-      cabal new-sdist all
-      mv dist-newstyle/sdist/*.tar.gz ${DISTDIR}/
-      cd ${DISTDIR} || false
-      find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
-      "printf 'packages: tidal-*/*.cabal\\n' > cabal.project"
-      "printf 'write-ghc-environment-files: always\\n' >> cabal.project"
-      touch cabal.project.local
-      "if ! $NOINSTALLEDCONSTRAINTS; then for pkg in $($HCPKG list --simple-output); do echo $pkg  | grep -vw -- tidal | sed 's/^/constraints: /' | sed 's/-[^-]*$/ installed/' >> cabal.project.local; done; fi"
-      cat cabal.project || true
-      cat cabal.project.local || true
-      # this builds all libraries and executables (without tests/benchmarks)
-      cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
-
-      # build & run tests, build benchmarks
-      cabal new-build -w ${HC} ${TEST} ${BENCH} all
-      if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
-
-      # cabal check
-      (cd tidal-* && cabal check)
-
-      # haddock
-      if $HADDOCK; then cabal new-haddock -w ${HC} ${TEST} ${BENCH} all; else echo "Skipping haddock generation";fi
-
-      # Build without installed constraints for packages in global-db
-      if $UNCONSTRAINED; then rm -f cabal.project.local; echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks all; else echo "Not building without installed constraints"; fi
+      cabal new-build
+      cabal new-test
+      ;;
+    cabal-old)
+      cabal build
+      cabal test
       ;;
     stack)
       stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps


### PR DESCRIPTION
Fixes #423.

I tried to simplify, and move to the bleeding edge world of `cabal new-*`, with some but limited success.

There is a case in there, with ghc-8.6.3, where `cabal build` works but `cabal new-build` doesn't, and complains about cairo.  It could be something, so I left the old cabal build in, and made the cabal new-build an allowable fail.