### PR TITLE
(WIP) Trying to make a Biapplicative instance of Pattern

### DIFF
--- a/src/Sound/Tidal/Control.hs
+++ b/src/Sound/Tidal/Control.hs
@@ -249,8 +249,8 @@ en ns p = stack $ map (\(i, (k, n)) -> _e k n (samples p (pure i))) $ enumerate 
 
 slice :: Pattern Int -> Pattern Int -> ControlPattern -> ControlPattern
 slice pN pI p = P.begin b # P.end e # p
-  where b = (\i n -> (div' i n)) <$> pI <* pN
-        e = (\i n -> (div' i n) + (div' 1 n)) <$> pI <* pN
+  where b = (\i n -> (div' i n)) <$> pI <*| pN
+        e = (\i n -> (div' i n) + (div' 1 n)) <$> pI <*| pN
         div' num den = fromIntegral (num `mod` den) / fromIntegral den
 
 _slice :: Int -> Int -> ControlPattern -> ControlPattern

--- a/src/Sound/Tidal/Core.hs
+++ b/src/Sound/Tidal/Core.hs
@@ -2,7 +2,7 @@
 
 module Sound.Tidal.Core where
 
-import           Prelude hiding ((<*), (*>))
+import           Prelude
 
 import           Data.Fixed (mod')
 import qualified Data.Map.Strict as Map
@@ -85,51 +85,51 @@ instance {-# OVERLAPPING #-} Unionable ControlMap where
 (|+|) :: (Applicative a, Num b) => a b -> a b -> a b
 a |+| b = (+) <$> a <*> b
 (|+ ) :: Num a => Pattern a -> Pattern a -> Pattern a
-a |+  b = (+) <$> a <* b
+a |+  b = (+) <$> a <*| b
 ( +|) :: Num a => Pattern a -> Pattern a -> Pattern a
-a  +| b = (+) <$> a *> b
+a  +| b = (+) <$> a |*> b
 
 (|/|) :: (Applicative a, Fractional b) => a b -> a b -> a b
 a |/| b = (/) <$> a <*> b
 (|/ ) :: Fractional a => Pattern a -> Pattern a -> Pattern a
-a |/  b = (/) <$> a <* b
+a |/  b = (/) <$> a <*| b
 ( /|) :: Fractional a => Pattern a -> Pattern a -> Pattern a
-a  /| b = (/) <$> a *> b
+a  /| b = (/) <$> a |*> b
 
 (|*|) :: (Applicative a, Num b) => a b -> a b -> a b
 a |*| b = (*) <$> a <*> b
 (|* ) :: Num a => Pattern a -> Pattern a -> Pattern a
-a |*  b = (*) <$> a <* b
+a |*  b = (*) <$> a <*| b
 ( *|) :: Num a => Pattern a -> Pattern a -> Pattern a
-a  *| b = (*) <$> a *> b
+a  *| b = (*) <$> a |*> b
 
 (|-|) :: (Applicative a, Num b) => a b -> a b -> a b
 a |-| b = (-) <$> a <*> b
 (|- ) :: Num a => Pattern a -> Pattern a -> Pattern a
-a |-  b = (-) <$> a <* b
+a |-  b = (-) <$> a <*| b
 ( -|) :: Num a => Pattern a -> Pattern a -> Pattern a
-a  -| b = (-) <$> a *> b
+a  -| b = (-) <$> a |*> b
 
 (|%|) :: (Applicative a, Real b) => a b -> a b -> a b
 a |%| b = mod' <$> a <*> b
 (|% ) :: Real a => Pattern a -> Pattern a -> Pattern a
-a |%  b = mod' <$> a <* b
+a |%  b = mod' <$> a <*| b
 ( %|) :: Real a => Pattern a -> Pattern a -> Pattern a
-a  %| b = mod' <$> a *> b
+a  %| b = mod' <$> a |*> b
 
 (|>|) :: (Applicative a, Unionable b) => a b -> a b -> a b
 a |>| b = (flip union) <$> a <*> b
 (|> ) :: Unionable a => Pattern a -> Pattern a -> Pattern a
-a |>  b = (flip union) <$> a <* b
+a |>  b = (flip union) <$> a <*| b
 ( >|) :: Unionable a => Pattern a -> Pattern a -> Pattern a
-a  >| b = (flip union) <$> a *> b
+a  >| b = (flip union) <$> a |*> b
 
 (|<|) :: (Applicative a, Unionable b) => a b -> a b -> a b
 a |<| b = union <$> a <*> b
 (|< ) :: Unionable a => Pattern a -> Pattern a -> Pattern a
-a |<  b = union <$> a <* b
+a |<  b = union <$> a <*| b
 ( <|) :: Unionable a => Pattern a -> Pattern a -> Pattern a
-a  <| b = union <$> a *> b
+a  <| b = union <$> a |*> b
 
 -- Backward compatibility - structure from left, values from right.
 (#) :: Unionable b => Pattern b -> Pattern b -> Pattern b

--- a/src/Sound/Tidal/Pattern.hs
+++ b/src/Sound/Tidal/Pattern.hs
@@ -157,8 +157,8 @@ instance Biapplicative EventF where
   (Event fw fp fv) <<*>> (Event xw xp xv) = Event (fw xw) (fp xp) (fv xv) 
 
 instance (Monoid a) => Applicative (EventF a) where
-  pure a = bipure mempty a
-  (Event fw fp fv) <*> (Event xw xp xv) = Event (fw <> xw) (fp <> xp) (fv xv)
+  pure = bipure mempty
+  (<*>) = biliftA2 mappend ($)
 
 nonEvent :: Event a -> Bool
 nonEvent (Event EmptyArc _ _) = True

--- a/src/Sound/Tidal/Transition.hs
+++ b/src/Sound/Tidal/Transition.hs
@@ -128,7 +128,7 @@ interpolate = interpolateIn 4
 interpolateIn :: Time -> Time -> [ControlPattern] -> ControlPattern
 interpolateIn _ _ [] = silence
 interpolateIn _ _ (p:[]) = p
-interpolateIn t now (pat:pat':_) = f <$> pat' *> pat <* automation
+interpolateIn t now (pat:pat':_) = f <$> pat' |*> pat <*| automation
   where automation = now `rotR` (_slow t envL)
         f = (\a b x -> Map.unionWith (fNum2 (\a' b' -> floor $ (fromIntegral a') * x + (fromIntegral b') * (1-x))
                                             (\a' b' -> a' * x + b' * (1-x))

--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -880,7 +880,7 @@ segment :: Pattern Time -> Pattern a -> Pattern a
 segment = tParam _segment
 
 _segment :: Time -> Pattern a -> Pattern a
-_segment n p = (_fast n $ pure (id)) <* p
+_segment n p = (_fast n $ pure (id)) <*| p
 
 -- | @discretise@: the old (deprecated) name for 'segment'
 discretise :: Pattern Time -> Pattern a -> Pattern a
@@ -953,7 +953,7 @@ permstep nSteps things p = unwrap $ (\n -> fastFromList $ concatMap (\x -> repli
 -- boolean values @a@. Only @True@ values in the boolean pattern are
 -- used.
 struct :: Pattern Bool -> Pattern a -> Pattern a
-struct ps pv = filterJust $ (\a b -> if a then Just b else Nothing ) <$> ps <* pv
+struct ps pv = filterJust $ (\a b -> if a then Just b else Nothing ) <$> ps <*| pv
 
 -- | @substruct a b@: similar to @struct@, but each event in pattern @a@ gets replaced with pattern @b@, compressed to fit the timespan of the event.
 substruct :: Pattern String -> Pattern b -> Pattern b
@@ -1321,7 +1321,7 @@ _ply n p = arpeggiate $ stack (replicate n p)
 -- Uses the first (binary) pattern to switch between the following two
 -- patterns.
 sew :: Pattern Bool -> Pattern a -> Pattern a -> Pattern a
-sew stitch p1 p2 = overlay (const <$> p1 <* a) (const <$> p2 <* b)
+sew stitch p1 p2 = overlay (const <$> p1 <*| a) (const <$> p2 <*| b)
   where a = filterValues (id) stitch
         b = filterValues (not . id) stitch
 

--- a/test/Sound/Tidal/CoreTest.hs
+++ b/test/Sound/Tidal/CoreTest.hs
@@ -52,13 +52,13 @@ run =
             (((1,4/3),   (1,4/3)),   "a"),
             (((4/3,5/3), (4/3,5/3)), "b")
           ]
-      it "works with zero-length queries" $ do
+      it "works with zero-length query arcs" $ do
         it "0" $
           queryArc (fastCat [pure "a", pure "b"]) (Arc 0 0)
-            `shouldBe` fmap toEvent [(((0,0.5), (0,0)), "a" :: String)]
+            `shouldBe` fmap toEvent [(((0,0), (0,0)), "a" :: String)]
         it "1/3" $
-          queryArc (fastCat [pure "a", pure "b"]) (Arc (1%3) (1%3))
-            `shouldBe` fmap toEvent [(((0,0.5), (1%3,1%3)), "a" :: String)]
+          queryArc (fastCat [pure "a", pure "b", pure "c"]) (Arc (1%3) (1%3))
+            `shouldBe` fmap toEvent [((((1%3),(1%3)), (1%3,1%3)), "b" :: String)]
 
     describe "rev" $ do
       it "mirrors events" $ do

--- a/test/Sound/Tidal/PatternTest.hs
+++ b/test/Sound/Tidal/PatternTest.hs
@@ -142,18 +142,18 @@ run =
 
     describe "<*" $ do
       it "can apply a pattern of values to a pattern of functions" $ do
-        queryArc ((pure (+1)) <* (pure 3)) (Arc 0 1) `shouldBe` fmap toEvent
+        queryArc ((pure (+1)) <*| (pure 3)) (Arc 0 1) `shouldBe` fmap toEvent
           [(((0,1), (0,1)), 4  :: Int)]
       it "doesn't take structure from the right" $ do
-        queryArc (pure (+1) <* (fastCat [pure 7, pure 8])) (Arc 0 1)
+        queryArc (pure (+1) <*| (fastCat [pure 7, pure 8])) (Arc 0 1)
           `shouldBe` fmap toEvent [(((0,1), (0,1)), 8 :: Int)]
 
     describe "*>" $ do
       it "can apply a pattern of values to a pattern of functions" $ do
-        it "works within cycles" $ queryArc ((pure (+1)) *> (pure 3)) (Arc 0 1) `shouldBe` fmap toEvent [(((0,1), (0,1)), 4  :: Int)]
-        it "works across cycles" $ queryArc ((pure (+1)) *> (slow 2 $ pure 3)) (Arc 0 1) `shouldBe` fmap toEvent [(((0,2), (0,1)), 4  :: Int)]
+        it "works within cycles" $ queryArc ((pure (+1)) |*> (pure 3)) (Arc 0 1) `shouldBe` fmap toEvent [(((0,1), (0,1)), 4  :: Int)]
+        it "works across cycles" $ queryArc ((pure (+1)) |*> (slow 2 $ pure 3)) (Arc 0 1) `shouldBe` fmap toEvent [(((0,2), (0,1)), 4  :: Int)]
       it "doesn't take structure from the left" $ do
-        queryArc (pure (+1) *> (fastCat [pure 7, pure 8])) (Arc 0 1)
+        queryArc (pure (+1) |*> (fastCat [pure 7, pure 8])) (Arc 0 1)
           `shouldBe` fmap toEvent
           [(((0,0.5), (0,0.5)), 8 :: Int),
             (((0.5,1), (0.5,1)), 9 :: Int)
@@ -372,10 +372,10 @@ run =
 
     describe "subArc" $ do
       it "Checks if an Arc is within another, returns Just (max $ (fst a1) (fst a2), min $ (snd a1) (snd a2)) if so, otherwise Nothing" $ do       
-        let res = subArc (Arc 2.1 2.4) (Arc 2.4 2.8)
+        let res = subArc (Arc 2.1 2.4) (Arc 2.4 2.8) :: Maybe Arc
         property $ Nothing === res
       it "if max (fst arc1) (fst arc2) <= min (snd arc1) (snd arc2) return Just (max (fst arc1) (fst arc2), min...)" $ do
-        let res = subArc (Arc 2 2.8) (Arc 2.4 2.9)
+        let res = subArc (Arc 2 2.8) (Arc 2.4 2.9) :: Maybe Arc
         property $ Just (Arc 2.4 2.8) === res
 
     describe "timeToCycleArc" $ do


### PR DESCRIPTION
continuing from #427

I made a Biapplicative instance of Event and used this to make an Applicative instance.  I pretty much followed https://www.well-typed.com/blog/2018/09/compositional-zooming/ which is the only example of biapplicative out there I could find.  What zooming has to do with patterns is a mystery right now.

To get a monoid thing from an Arc, I had to add a concept of an EmptyArc, so that intersection (based on subArc) could be `Arc -> Arc -> Arc`.  I also needed a unit - something that when intersected with an arc gives you back the arc.  It would be great to use `Arc 0 infinity` but Rational hasn't got an infinity.

The end game is that `<*>` for Pattern could be something like:

```
(<*>) pf px = Pattern Digital $ \st ->
    filter (not . nonEvent) ((<*>) <$> query pf st <*> query px st)
```
which is at least a little bit awesome. Use the spaceship for lists to apply the spaceship for events (intersect the arcs and apply the values), then filter out the non-intersecting events.

`*>` and `<*` are very interesting.  Since these are already used in Control.Applicative, and are famous, I changed them to `|*>` and `<*|`.    `*>` is action then throw away the left computation and just give me the right one.  `|*>` is throw away the left structure and go with the right one, but `<*>` the values.  If Pattern was a biapplicative, then structure would mean the first of the applicatives that operate on the arc elements.  
In https://hackage.haskell.org/package/bifunctors-5.5.3/docs/Data-Biapplicative.html it might be called `|<*>>` meaning throw away the first applicative of the first computation but keep the rest. Maybe you can't throw it away and it's better expressed as compute it, but then stick the old first left applicative in. Regardless none of this exists and I cant find any reference to anyone having thought about it.

Very much a work-in-progress.

Edit: added backtics






