### PR TITLE
david minnix - saw that yaxu had already fixed the bug but added a un…

### DIFF
--- a/test/Sound/Tidal/UITest.hs
+++ b/test/Sound/Tidal/UITest.hs
@@ -58,6 +58,14 @@ run =
           in
             compareP overTimeSpan testMe expectedResult
 
+      it "does nothing when set at 0% probability -- const" $ do
+        let
+          overTimeSpan = (Arc 0  2)
+          testMe = sometimesBy 0 (const $ s "cp") (s "bd*8")
+          expectedResult = s "bd*8"
+          in
+            compareP overTimeSpan testMe expectedResult
+
       it "applies the 'rev' function when set at 100% probability" $ do
         let
           overTimeSpan = (Arc 0  1)
@@ -169,3 +177,4 @@ run =
         compareP (Arc 0 1)
           (euclidFull 3 8 "bd" silence)
           ("bd(3,8)" :: Pattern String)
+        


### PR DESCRIPTION
…it test to prevent regressions

Hi,

I saw the bug description and started this branch to take a shot at fixing. Then I saw that @yaxu had already fixed it! I had already written a unit test to check for the bug. It fails appropriately when the fix to sometimesBy is removed. I though I might as well open a PR as the test might be useful for preventing regressions. 

Cheers,

David