### PR TITLE
Change to record assignment so `cps` works again

### DIFF
--- a/src/Sound/Tidal/Tempo.hs
+++ b/src/Sound/Tidal/Tempo.hs
@@ -40,17 +40,18 @@ data State = State {ticks   :: Int,
 changeTempo :: MVar Tempo -> (O.Time -> Tempo -> Tempo) -> IO Tempo
 changeTempo tempoMV f = do t <- O.time
                            tempo <- takeMVar tempoMV
-                           let tempo' = f t $ tempo {atTime = t}
+                           let tempo' = f t $ tempo
                            sendTempo tempo'
                            putMVar tempoMV tempo'
                            return tempo'
 
 
 resetCycles :: MVar Tempo -> IO Tempo
-resetCycles tempoMV = changeTempo tempoMV (\_ tempo -> tempo {atCycle = 0})
+resetCycles tempoMV = changeTempo tempoMV (\t tempo -> tempo {atTime = t, atCycle = 0})
 
 setCps :: MVar Tempo -> O.Time -> IO Tempo
-setCps tempoMV newCps = changeTempo tempoMV (\t tempo -> tempo {atCycle = timeToCycles tempo t,
+setCps tempoMV newCps = changeTempo tempoMV (\t tempo -> tempo {atTime = t,
+                                                                atCycle = timeToCycles tempo t,
                                                                 cps = newCps
                                                                })
 


### PR DESCRIPTION
A recent commit c0c092d5597f9ee57fc188fd286d368454b10e68 broke the usage of `cps` in patterns.

I'm not entirely clear on the _why_, but it has something to do with record initialization in Tempo type.  I've moved things around so `cps` works again.  I'm still unclear whether `resetCycles` is doing what it's supposed to do, as I'm not sure when it gets invoked.  But `setCps` should work again.