### PR TITLE
add support for new spectral fx

### DIFF
--- a/src/Sound/Tidal/Params.hs
+++ b/src/Sound/Tidal/Params.hs
@@ -385,6 +385,44 @@ ringdf = pF "ringdf"
 distort :: Pattern Double -> ControlPattern
 distort = pF "distort"
 
+-- Spectral conform
+real :: Pattern Double -> ControlPattern
+real = pF "real"
+
+imag :: Pattern Double -> ControlPattern
+imag = pF "imag"
+
+-- Spectral enhance
+enhance :: Pattern Double -> ControlPattern
+enhance = pF "enhance"
+
+partials :: Pattern Double -> ControlPattern
+partials = pF "partials"
+
+-- Spectral comb
+comb :: Pattern Double -> ControlPattern
+comb = pF "comb"
+
+-- Spectral smear
+smear :: Pattern Double -> ControlPattern
+smear = pF "smear"
+
+-- Spectral scramble
+scram :: Pattern Double -> ControlPattern
+scram = pF "scram"
+
+-- Spectral binshift
+binshift :: Pattern Double -> ControlPattern
+binshift = pF "binshift"
+
+-- High pass sort of spectral filter
+hbrick :: Pattern Double -> ControlPattern
+hbrick = pF "hbrick"
+
+-- Low pass sort of spectral filter
+lbrick :: Pattern Double -> ControlPattern
+lbrick = pF "lbrick"
+
 -- aliases
 att, bpf, bpq, chdecay, ctf, ctfg, delayfb, delayt, det, gat, hg, hpf, hpq, lag, lbd, lch, lcl, lcp, lcr, lfoc, lfoi
    , lfop, lht, llt, loh, lpf, lpq, lsn, ohdecay, phasdp, phasr, pit1, pit2, pit3, por, rel, sz, sag, scl, scp

--- a/src/Sound/Tidal/Params.hs
+++ b/src/Sound/Tidal/Params.hs
@@ -385,6 +385,17 @@ ringdf = pF "ringdf"
 distort :: Pattern Double -> ControlPattern
 distort = pF "distort"
 
+-- Spectral freeze
+freeze :: Pattern Double -> ControlPattern
+freeze = pF "freeze"
+
+-- Spectral delay
+xsdelay :: Pattern Double -> ControlPattern
+xsdelay = pF "xsdelay"
+
+tsdelay :: Pattern Double -> ControlPattern
+tsdelay = pF "tsdelay"
+
 -- Spectral conform
 real :: Pattern Double -> ControlPattern
 real = pF "real"


### PR DESCRIPTION
Add new parameters to be used with the SpectralTricks fx that are now added to SuperDirt by default, see [superdirt pull request](https://github.com/musikinformatik/SuperDirt/pull/113)