### PR TITLE
load BootTidal.hs in emacs without manual config

### DIFF
--- a/tidal.cabal
+++ b/tidal.cabal
@@ -13,6 +13,7 @@ category:            Sound
 build-type:          Simple
 cabal-version:       >=1.10
 tested-with:         GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.3
+data-files:          BootTidal.hs
 
 Extra-source-files: README.md CHANGELOG.md tidal.el
 

--- a/tidal.el
+++ b/tidal.el
@@ -57,6 +57,14 @@
   ()
   "*Arguments to the haskell interpreter (default=none).")
 
+(defvar tidal-boot-script-path
+  (concat (substring
+           (shell-command-to-string
+            "ghc-pkg describe $(ghc-pkg latest tidal) | grep data-dir | cut -f2 -d' '") 0 -1)
+          "/BootTidal.hs")
+  "*Full path to BootTidal.hs (inferred by introspecting ghc-pkg package db)."
+  )
+
 (defvar tidal-literate-p
   t
   "*Flag to indicate if we are in literate mode (default=t).")
@@ -87,60 +95,7 @@
      nil
      tidal-interpreter-arguments)
     (tidal-see-output))
-  (tidal-send-string ":set prompt \"\"")
-  (if (string< tidal-interpreter-version "8.2.0")
-      (tidal-send-string ":set prompt2 \"\"")
-    (tidal-send-string ":set prompt-cont \"\""))
-  (tidal-send-string ":set -XOverloadedStrings
-import Sound.Tidal.Context
-tidal <- startMulti [superdirtTarget {oLatency = 0.1, oAddress = \"127.0.0.1\", oPort = 57120}] (defaultConfig {cFrameTimespan = 1/20, cCtrlListen = True})
-let p = streamReplace tidal
-let hush = streamHush tidal
-let list = streamList tidal
-let mute = streamMute tidal
-let unmute = streamUnmute tidal
-let solo = streamSolo tidal
-let unsolo = streamUnsolo tidal
-let once = streamOnce tidal False
-let asap = streamOnce tidal True
-let nudgeAll = streamNudgeAll tidal
-let all = streamAll tidal
-let resetCycles = streamResetCycles tidal
-let setcps = asap . cps
-let xfade i = transition tidal (Sound.Tidal.Transition.xfadeIn 4) i
-let xfadeIn i t = transition tidal (Sound.Tidal.Transition.xfadeIn t) i
-let histpan i t = transition tidal (Sound.Tidal.Transition.histpan t) i
-let wait i t = transition tidal (Sound.Tidal.Transition.wait t) i
-let waitT i f t = transition tidal (Sound.Tidal.Transition.waitT f t) i
-let jump i = transition tidal (Sound.Tidal.Transition.jump) i
-let jumpIn i t = transition tidal (Sound.Tidal.Transition.jumpIn t) i
-let jumpIn' i t = transition tidal (Sound.Tidal.Transition.jumpIn' t) i
-let jumpMod i t = transition tidal (Sound.Tidal.Transition.jumpMod t) i
-let mortal i lifespan release = transition tidal (Sound.Tidal.Transition.mortal lifespan release) i
-let interpolate i = transition tidal (Sound.Tidal.Transition.interpolate) i
-let interpolateIn i t = transition tidal (Sound.Tidal.Transition.interpolateIn t) i
-let clutch i = transition tidal (Sound.Tidal.Transition.clutch) i
-let clutchIn i t = transition tidal (Sound.Tidal.Transition.clutchIn t) i
-let anticipate i = transition tidal (Sound.Tidal.Transition.anticipate) i
-let anticipateIn i t = transition tidal (Sound.Tidal.Transition.anticipateIn t) i
-let d1 = p 1
-let d2 = p 2 . (|< orbit 1)
-let d3 = p 3 . (|< orbit 2)
-let d4 = p 4 . (|< orbit 3)
-let d5 = p 5 . (|< orbit 4)
-let d6 = p 6 . (|< orbit 5)
-let d7 = p 7 . (|< orbit 6)
-let d8 = p 8 . (|< orbit 7)
-let d9 = p 9 . (|< orbit 8)
-let d10 = p 10
-let d11 = p 11
-let d12 = p 12
-let d13 = p 13
-let d14 = p 14
-let d15 = p 15
-let d16 = p 16
-  ")
-  (tidal-send-string ":set prompt \"tidal> \"")
+  (tidal-send-string (concat ":script " tidal-boot-script-path))
 )
 
 (defun tidal-see-output ()


### PR DESCRIPTION
infers path to BootTidal.hs and loads it in `tidal.el`

this way we only have to maintain one bootscript.

this works as long as `ghc-pkg` can be found in path and tidal is installed via `cabal install` in the global package database.

however, you can point to you custom `BootTidal.hs` via
```
(setq tidal-boot-script-path "~/MyTidalBoot.hs")
```

In order for this to work out-of-the-box we have to add the `BootTidal.hs` as a data-file in `.cabal`.

We try to infer the path of the installed tidal by asking for the data-dir of the latest installed version of tidal.

this duplicates #482 but should merge cleanly into current master