### PR TITLE
Fixes `stretch` so that `fit'` works again.  

### DIFF
--- a/src/Sound/Tidal/Pattern.hs
+++ b/src/Sound/Tidal/Pattern.hs
@@ -88,6 +88,10 @@ instance Applicative ArcF where
 timeToCycleArc :: Time -> Arc
 timeToCycleArc t = Arc (sam t) (sam t + 1)
 
+-- | Shifts an arc to the equivalent one that starts during cycle zero
+cycleArc :: Arc -> Arc
+cycleArc (Arc s e) = Arc (cyclePos s) (cyclePos s + (e-s))
+
 -- | A list of cycle numbers which are included in the given arc
 cyclesInArc :: Integral a => Arc -> [a]
 cyclesInArc (Arc s e)
@@ -380,7 +384,6 @@ squeezeJoin pp = pp {query = q}
           do w' <- subArc oWhole iWhole
              p' <- subArc oPart iPart
              return (Event w' p' v)
-        cycleArc (Arc s e) = Arc (cyclePos s) (cyclePos s + (e-s))
 
 noOv :: String -> a
 noOv meth = error $ meth ++ ": not supported for patterns"

--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -1101,7 +1101,7 @@ enclosingArc as = Arc (minimum (map start as)) (maximum (map stop as))
 stretch :: Pattern a -> Pattern a
 -- TODO - should that be whole or part?
 stretch p = splitQueries $ p {query = q}
-  where q st = query (zoomArc (enclosingArc $ map whole $ query p (st {arc = Arc (sam s) (nextSam s)})) p) st
+  where q st = query (zoomArc (cycleArc $ enclosingArc $ map whole $ query p (st {arc = Arc (sam s) (nextSam s)})) p) st
           where s = start $ arc st
 
 {- | `fit'` is a generalization of `fit`, where the list is instead constructed by using another integer pattern to slice up a given pattern.  The first argument is the number of cycles of that latter pattern to use when slicing.  It's easier to understand this with a few examples:


### PR DESCRIPTION
Also, since the functionality is used multiple times, factor out a new function `cycleArc` for turning an Arc into one that begins during cycle zero.  `zoomArc` needs such Arcs to work correctly.