### PR TITLE
Add explicit Ord and Eq instances for the Value type

### DIFF
--- a/src/Sound/Tidal/Pattern.hs
+++ b/src/Sound/Tidal/Pattern.hs
@@ -224,7 +224,25 @@ data Pattern a = Pattern {nature :: Nature, query :: Query a}
 data Value = VS { svalue :: String }
            | VF { fvalue :: Double }
            | VI { ivalue :: Int }
-           deriving (Eq,Ord,Typeable,Data)
+           deriving (Typeable,Data)
+
+instance Eq Value where
+  (VS x) == (VS y) = x == y
+  (VF x) == (VF y) = x == y
+  (VI x) == (VI y) = x == y
+  (VS x) == _ = False
+  _ == (VS y) = False
+  (VF x) == (VI y) = x == (fromIntegral y)
+  (VI x) == (VF y) = (fromIntegral x) == y
+
+instance Ord Value where
+  compare (VS x) (VS y) = compare x y
+  compare (VF x) (VF y) = compare x y
+  compare (VI x) (VI y) = compare x y
+  compare (VS x) _ = LT
+  compare _ (VS x) = GT
+  compare (VF x) (VI y) = compare x (fromIntegral y)
+  compare (VI x) (VF y) = compare (fromIntegral x) y
 
 type ControlMap = Map.Map String Value
 type ControlPattern = Pattern ControlMap


### PR DESCRIPTION
With this change it's now possible to sensibly compare Values of different types.  VS are always less than the numeric types, and
```
tidal> VF 1 < VI 2
True

tidal> VI 1 < VF 2
True
```

This also means expressions such as `(>=) <$> n "1 3" <*> n 2` or even `(>=) <$> n "1 3" <*> 2` gives `(0>½)|False   (½>1)|True` as one would expect.

When using `fmap` in such a way it's still possible to uncover some strange situations when trying to compare maps with different sets of keys.  I don't know if it's possible to resolve all of those -- for now I leave it for another PR :)