### PR TITLE
Bug fix for elongation calculation (`"<a _ _ b _ >"`)

### DIFF
--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -250,7 +250,10 @@ pSequenceN f = do spaces
                                <|> do es <- many1 (symbol "_")
                                       return [TPat_Elongate (length es)]
                   let ps' = TPat_Cat $ map elongate $ splitFeet $ concat ps
-                  return (length ps, ps')
+                      extraElongate (TPat_Elongate n) = n-1
+                      extraElongate _ = 0
+                      sumElongates x = sum (map extraElongate x)
+                  return (length ps + sumElongates (concat ps), ps')
 
 elongate :: [TPat a] -> TPat a
 elongate xs | any isElongate xs = TPat_TimeCat xs

--- a/test/Sound/Tidal/ParseTest.hs
+++ b/test/Sound/Tidal/ParseTest.hs
@@ -34,6 +34,10 @@ run =
         compareP (Arc 0 2)
           ("a*8" :: Pattern String)
           (fast 8 "a")
+      it "can elongate with _" $ do
+        compareP (Arc 0 2)
+          ("a _ _ b _" :: Pattern String)
+          (timeCat [(3,"a"), (2,"b")])
       it "can do polymeter with {}" $ do
         compareP (Arc 0 2)
           ("{a b, c d e}" :: Pattern String)


### PR DESCRIPTION
There was an issue preventing repeated elongations being counted in patterns like `"<a _ _ b _>"`  I've implemented a work-around to fix it.