### PR TITLE
Initial commit of Markov chain tools

### DIFF
--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -1051,7 +1051,7 @@ rationals are required) -}
 lindenmayerI :: Num b => Int -> String -> String -> [b]
 lindenmayerI n r s = fmap (fromIntegral . digitToInt) $ lindenmayer n r s
 
-{- | @runMarkov@ n tmat xi@ generates a Markov chain (as a list) of length @n@
+{- | @runMarkov n tmat xi@ generates a Markov chain (as a list) of length @n@
 using the transition matrix @tmat@ starting from initial state @xi@.
 Each entry in the chain is the index of state (starting from zero). 
 Each row of the matrix will be automatically normalized. For example:
@@ -1069,7 +1069,7 @@ runMarkov n tp xi = reverse $ (iterate (markovStep $ renorm tp) [xi])!! (n-1) wh
 
 {- @markovPat n xi tp@ generates a one-cycle pattern of @n@ steps in a Markov
 chain starting from state @xi@ with transition matrix @tp@. Each row of the
-transition matrix is automaticaly normalized.  For example:
+transition matrix is automatically normalized.  For example:
 @
 tidal> markovPat 8 1 [[3,5,2], [4,4,2], [0,1,0]]
 


### PR DESCRIPTION
`runMarkov n tmat xi` generates a Markov chain (as a list) of length `n`
using the transition matrix `tmat` starting from initial state `xi`.
Each entry in the chain is the index of state (starting from zero). 
Each row of the matrix will be automatically normalized. For example:
```
runMarkov 8 [[2,3], [1,3]] 0
```
will produce a two-state chain 8 steps long, from initial state 0, where the
transition probability from state 0->0 is 2/5, 0->1 is 3/5, 1->0 is 1/4, and 
1->1 is 3/4.

`markovPat n xi tp` generates a one-cycle pattern of `n` steps in a Markov
chain starting from state `xi` with transition matrix `tp`. Each row of the
transition matrix is automatically normalized.  For example:
```
tidal> markovPat 8 1 [[3,5,2], [4,4,2], [0,1,0]]

(0>⅛)|1
(⅛>¼)|2
(¼>⅜)|1
(⅜>½)|1
(½>⅝)|2
(⅝>¾)|1
(¾>⅞)|1
(⅞>1)|0
```
