### PR TITLE
define arpeggiate with arpWith

### DIFF
--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -1293,17 +1293,8 @@ layer fs p = stack $ map ($ p) fs
 -- | @arpeggiate@ finds events that share the same timespan, and spreads
 -- them out during that timespan, so for example @arpeggiate "[bd,sn]"@
 -- gets turned into @"bd sn"@. Useful for creating arpeggios/broken chords.
-arpeggiate :: Pattern a -> Pattern a
-arpeggiate p = withEvents munge p
-  where munge es = concatMap spreadOut (groupBy (\a b -> whole a == whole b) es)
-        spreadOut xs = mapMaybe (\(n, x) -> shiftIt n (length xs) x) $ enumerate xs
-        shiftIt n d (Event (Arc s e) a' v) =
-          do
-            a'' <- subArc (Arc newS newE) a'
-            return (Event (Arc newS newE) a'' v)
-          where newS = s + (dur * fromIntegral n)
-                newE = newS + dur
-                dur = (e - s) / fromIntegral d
+arpeggiate :: Pattern a -> Pattern a 
+arpeggiate = arpWith id
 
 -- | Shorthand alias for arpeggiate
 arpg :: Pattern a -> Pattern a

--- a/test/Sound/Tidal/UITest.hs
+++ b/test/Sound/Tidal/UITest.hs
@@ -119,6 +119,7 @@ run =
           it "at 1/2 of a cycle" $
             (queryArc (Sound.Tidal.UI.range 10 10 saw) (Arc 0.5 0.5)) `shouldBe` fmap toEvent
               [(((0.5, 0.5), (0.5, 0.5)), 10 :: Float)]
+
     describe "rot" $ do
       it "rotates values in a pattern irrespective of structure" $
         property $ comparePD (Arc 0 2)
@@ -249,3 +250,9 @@ run =
         compareP (Arc 0 4)
           (bite 4 "0 2*2" (Sound.Tidal.Core.run 8))
           ("[0 1] [4 5]*2" :: Pattern Int)
+
+    describe "arpeggiate" $ 
+      it "spreads out events that share a timespan over that timespan" $ 
+         compareP (Arc 0 1) 
+           (arpeggiate ("[bd, sn] [hh:1, cp]" :: Pattern String))
+           ("bd sn hh:1 cp" :: Pattern String)


### PR DESCRIPTION
just avoids some duplication, had to change the arpWtih function slightly by adding the 'sortOn whole es' bit to munge, so feel free to ignore this if that's an issue.