### PR TITLE
Add support for inversions to chord parser:

### DIFF
--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -366,8 +366,11 @@ parseChord = do char '\''
                 name <- many1 $ letter <|> digit
                 let chord = fromMaybe [0] $ lookup name chordTable
                 do char '\''
-                   i <- integer <?> "chord range"
-                   let chord' = take (fromIntegral i) $ concatMap (\x -> map (+ x) chord) [0,12..]
+                   notFollowedBy space <?> "chord range or 'i'"
+                   let n = length chord
+                   i <- option n (fromIntegral <$> integer)
+                   j <- length <$> many (char 'i')
+                   let chord' = take i $ drop j $ concatMap (\x -> map (+ x) chord) [0,12..]
                    return chord'
                   <|> return chord
 


### PR DESCRIPTION
`"c'major'i"` will give [4,7,12]
`"c'major'ii"` will give [7,12,16]
`"c'major'4ii"` will give [7,12,16,19]