### PR TITLE
Topic dualistic events

### DIFF
--- a/src/Sound/Tidal/Core.hs
+++ b/src/Sound/Tidal/Core.hs
@@ -20,7 +20,7 @@ sig :: (Time -> a) -> Pattern a
 sig f = Pattern q
   where q (State (Arc s e) _)
           | s > e = []
-          | otherwise = [Event (Arc s e) (Arc s e) (f (s+((e-s)/2)))]
+          | otherwise = [Event Nothing (Arc s e) (f (s+((e-s)/2)))]
 
 -- | @sine@ returns a 'Pattern' of continuous 'Fractional' values following a
 -- sinewave with frequency of one cycle, and amplitude from 0 to 1.
@@ -303,11 +303,13 @@ rev p =
         })
     }
   where makeWholeRelative :: Event a -> Event a
-        makeWholeRelative (Event (Arc s e) p'@(Arc s' e') v) =
-          Event (Arc (s'-s) (e'-e)) p' v
+        makeWholeRelative (e@(Event Nothing _ _)) = e
+        makeWholeRelative (Event (Just (Arc s e)) p'@(Arc s' e') v) =
+          Event (Just $ Arc (s'-s) (e'-e)) p' v
         makeWholeAbsolute :: Event a -> Event a
-        makeWholeAbsolute (Event (Arc s e) p'@(Arc s' e') v) =
-          Event (Arc (s'-e) (e'+s)) p' v
+        makeWholeAbsolute (e@(Event Nothing _ _)) = e
+        makeWholeAbsolute (Event (Just (Arc s e)) p'@(Arc s' e') v) =
+          Event (Just $ Arc (s'-e) (e'+s)) p' v
         midCycle :: Arc -> Time
         midCycle (Arc s _) = sam s + 0.5
         mapParts :: (Arc -> Arc) -> [Event a] -> [Event a]

--- a/src/Sound/Tidal/Core.hs
+++ b/src/Sound/Tidal/Core.hs
@@ -305,7 +305,7 @@ rev p =
   where makeWholeRelative :: Event a -> Event a
         makeWholeRelative (e@(Event Nothing _ _)) = e
         makeWholeRelative (Event (Just (Arc s e)) p'@(Arc s' e') v) =
-          Event (Just $ Arc (s'-s) (e'-e)) p' v
+          Event (Just $ Arc (s'-s) (e-e')) p' v
         makeWholeAbsolute :: Event a -> Event a
         makeWholeAbsolute (e@(Event Nothing _ _)) = e
         makeWholeAbsolute (Event (Just (Arc s e)) p'@(Arc s' e') v) =

--- a/src/Sound/Tidal/Pattern.hs
+++ b/src/Sound/Tidal/Pattern.hs
@@ -86,6 +86,12 @@ subArc a@(Arc s e) b@(Arc s' e')
   | otherwise = Nothing
   where (Arc s'' e'') = sect a b
 
+subMaybeArc :: Maybe Arc -> Maybe Arc -> Maybe (Maybe Arc)
+subMaybeArc Nothing b = Just b
+subMaybeArc a Nothing = Just a
+subMaybeArc (Just a) (Just b) = do sa <- subArc a b
+                                   return $ Just sa
+
 instance Applicative ArcF where
   pure t = Arc t t
   (<*>) (Arc sf ef) (Arc sx ex) = Arc (sf sx) (ef ex)
@@ -131,11 +137,10 @@ mapCycle f (Arc s e) = Arc (sam' + f (s - sam')) (sam' + f (e - sam'))
 isIn :: Arc -> Time -> Bool
 isIn (Arc s e) t = t >= s && t < e
 
--- | An event is a value that's active during a timespan
--- The part should be equal to or fit inside the
--- whole
+-- | An event is a value that's active during a timespan. If a whole
+-- is present, the part should be equal to or fit inside it.
 data EventF a b = Event
-  { whole :: a
+  { whole :: Maybe a
   , part :: a
   , value :: b
   } deriving (Eq, Ord, Functor)
@@ -146,16 +151,26 @@ instance (NFData a, NFData b) =>
   NFData (EventF a b) where 
     rnf (Event w p v) = rnf w `seq` rnf p `seq` rnf v
 
-instance Bifunctor EventF where
+{-instance Bifunctor EventF where
   bimap f g (Event w p e) = Event (f w) (f p) (g e)
+-}
 
 instance {-# OVERLAPPING #-} Show a => Show (Event a) where
-  show (Event (Arc ws we) a@(Arc ps pe) e) =
+  show (Event (Just (Arc ws we)) a@(Arc ps pe) e) =
     h ++ "(" ++ show a ++ ")" ++ t ++ "|" ++ show e
     where h | ws == ps = ""
             | otherwise = prettyRat ws ++ "-"
           t | we == pe = ""
             | otherwise = "-" ++ prettyRat we
+  show (Event Nothing a@(Arc ps pe) e) =
+    "~" ++ show a ++ "~|" ++ show e
+
+isAnalog :: Event a -> Bool
+isAnalog (Event {whole = Nothing}) = True
+isAnalog _ = False
+
+isDigital :: Event a -> Bool
+isDigital = not . isAnalog
 
 -- | `True` if an `Event`'s starts is within given `Arc`
 onsetIn :: Arc -> Event a -> Bool
@@ -186,13 +201,17 @@ isAdjacent e e' = (whole e == whole e')
                       (stop (part e') == start (part e))
                      )
 
+wholeOrPart :: Event a -> Arc
+wholeOrPart (Event {whole = Just a}) = a
+wholeOrPart e = part e
+
 -- | Get the onset of an event's 'whole'
 wholeStart :: Event a -> Time
-wholeStart = start . whole
+wholeStart = start . wholeOrPart
 
 -- | Get the offset of an event's 'whole'
 wholeStop :: Event a -> Time
-wholeStop = stop . whole
+wholeStop = stop . wholeOrPart
 
 -- | Get the onset of an event's 'whole'
 eventPartStart :: Event a -> Time
@@ -210,10 +229,12 @@ eventValue :: Event a -> a
 eventValue = value
 
 eventHasOnset :: Event a -> Bool
-eventHasOnset e = start (whole e) == start (part e)
+eventHasOnset e | isAnalog e = False
+                | otherwise = start (fromJust $ whole e) == start (part e)
 
+-- TODO - Is this used anywhere?
 toEvent :: (((Time, Time), (Time, Time)), a) -> Event a
-toEvent (((ws, we), (ps, pe)), v) = Event (Arc ws we) (Arc ps pe) v
+toEvent (((ws, we), (ps, pe)), v) = Event (Just $ Arc ws we) (Arc ps pe) v
 
 -- | an Arc and some named control values
 data State = State {arc :: Arc,
@@ -307,25 +328,25 @@ instance Functor Pattern where
   -- | apply a function to all the values in a pattern
   fmap f p = p {query = fmap (fmap f) . query p}
 
-applyPatToPat :: (Arc -> Arc -> Maybe Arc) -> Pattern (a -> b) -> Pattern a -> Pattern b
+applyPatToPat :: (Maybe Arc -> Maybe Arc -> Maybe (Maybe Arc)) -> Pattern (a -> b) -> Pattern a -> Pattern b
 applyPatToPat combineWholes pf px = Pattern q
     where q st = catMaybes $ concatMap match $ query pf st
             where
-              match (Event fWhole fPart f) =
+              match (e@(Event fWhole fPart f)) =
                 map
                 (\(Event xWhole xPart x) ->
                   do whole' <- combineWholes fWhole xWhole
                      part' <- subArc fPart xPart
                      return (Event whole' part' (f x))
                 )
-                (query px $ st {arc = fPart})
+                (query px $ st {arc = wholeOrPart e})
 
 instance Applicative Pattern where
   -- | Repeat the given value once per cycle, forever
   pure v = Pattern $ \(State a _) ->
-    map (\a' -> Event a' (sect a a') v) $ cycleArcsInArc a
+    map (\a' -> Event (Just a') (sect a a') v) $ cycleArcsInArc a
 
-  (<*>) = applyPatToPat subArc
+  (<*>) = applyPatToPat subMaybeArc
 
 -- | Like <*>, but the 'wholes' come from the left
 (<*) :: Pattern (a -> b) -> Pattern a -> Pattern b
@@ -359,7 +380,7 @@ unwrap pp = pp {query = q}
           (query pp st)
         munge ow op (Event iw ip v') =
           do
-            w' <- subArc ow iw
+            w' <- subMaybeArc ow iw
             p' <- subArc op ip
             return (Event w' p' v')
 
@@ -382,8 +403,8 @@ innerJoin pp = pp {query = q}
 outerJoin :: Pattern (Pattern a) -> Pattern a
 outerJoin pp = pp {query = q}
   where q st = concatMap
-          (\(Event w p v) ->
-             mapMaybe (munge w p) $ query v st {arc = pure (start w)}
+          (\e ->
+             mapMaybe (munge (whole e) (part e)) $ query (value e) st {arc = pure (start $ wholeOrPart e)}
           )
           (query pp st)
           where munge ow op (Event _ _ v') =
@@ -397,12 +418,12 @@ outerJoin pp = pp {query = q}
 squeezeJoin :: Pattern (Pattern a) -> Pattern a
 squeezeJoin pp = pp {query = q}
   where q st = concatMap
-          (\(Event w p v) ->
-             mapMaybe (munge w p) $ query (compressArc (cycleArc w) v) st {arc = p}
+          (\e@(Event w p v) ->
+             mapMaybe (munge w p) $ query (compressArc (cycleArc $ wholeOrPart e) v) st {arc = p}
           )
           (query pp st)
         munge oWhole oPart (Event iWhole iPart v) =
-          do w' <- subArc oWhole iWhole
+          do w' <- subMaybeArc oWhole iWhole
              p' <- subArc oPart iPart
              return (Event w' p' v)
 
@@ -612,7 +633,7 @@ splitQueries p = p {query = \st -> concatMap (\a -> query p st {arc = a}) $ arcC
 -- | Apply a function to the arcs/timespans (both whole and parts) of the result
 withResultArc :: (Arc -> Arc) -> Pattern a -> Pattern a
 withResultArc f pat = pat
-  { query = map (\(Event w p e) -> Event (f w) (f p) e) . query pat}
+  { query = map (\(Event w p e) -> Event (f <$> w) (f p) e) . query pat}
 
 -- | Apply a function to the time (both start and end of the timespans
 -- of both whole and parts) of the result
@@ -730,7 +751,16 @@ filterWhen :: (Time -> Bool) -> Pattern a -> Pattern a
 filterWhen test p = p {query = filter (test . wholeStart) . query p}
 
 filterOnsets :: Pattern a -> Pattern a
-filterOnsets p = p {query = filter (\e -> eventPartStart e == wholeStart e) . query p}
+filterOnsets p = p {query = filter (\e -> eventPartStart e == wholeStart e) . query (filterDigital p)}
+
+filterEvents :: (Event a -> Bool) -> Pattern a -> Pattern a
+filterEvents f p = p {query = filter f . query p}
+
+filterDigital :: Pattern a -> Pattern a
+filterDigital = filterEvents isDigital
+
+filterAnalog :: Pattern a -> Pattern a
+filterAnalog = filterEvents isAnalog
 
 playFor :: Time -> Time -> Pattern a -> Pattern a
 playFor s e = filterWhen (\t -> (t >= s) && (t < e))
@@ -755,7 +785,7 @@ matchManyToOne :: (b -> a -> Bool) -> Pattern a -> Pattern b -> Pattern (Bool, b
 matchManyToOne f pa pb = pa {query = q}
   where q st = map match $ query pb st
           where
-            match (Event xWhole xPart x) =
-              Event xWhole xPart (any (f x) (as $ start xWhole), x)
+            match (ex@(Event xWhole xPart x)) =
+              Event xWhole xPart (any (f x) (as $ start $ wholeOrPart ex), x)
             as s = map value $ query pa $ fQuery s
             fQuery s = st {arc = Arc s s}

--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -196,16 +196,16 @@ degradeBy :: Pattern Double -> Pattern a -> Pattern a
 degradeBy = tParam _degradeBy
 
 _degradeBy :: Double -> Pattern a -> Pattern a
-_degradeBy x p = fmap fst $ filterValues ((> x) . snd) $ (,) <$> p <*> rand
+_degradeBy x p = fmap fst $ filterValues ((> x) . snd) $ (,) <$> p <* rand
 
 unDegradeBy :: Pattern Double -> Pattern a -> Pattern a
 unDegradeBy = tParam _unDegradeBy
 
 _unDegradeBy :: Double -> Pattern a -> Pattern a
-_unDegradeBy x p = fmap fst $ filterValues ((<= x) . snd) $ (,) <$> p <*> rand
+_unDegradeBy x p = fmap fst $ filterValues ((<= x) . snd) $ (,) <$> p <* rand
 
 degradeOverBy :: Int -> Pattern Double -> Pattern a -> Pattern a
-degradeOverBy i tx p = unwrap $ (\x -> fmap fst $ filterValues ((> x) . snd) $ (,) <$> p <*> fastRepeatCycles i rand) <$> slow (fromIntegral i) tx
+degradeOverBy i tx p = unwrap $ (\x -> fmap fst $ filterValues ((> x) . snd) $ (,) <$> p <* fastRepeatCycles i rand) <$> slow (fromIntegral i) tx
 
 
 {- | Use @sometimesBy@ to apply a given function "sometimes". For example, the

--- a/src/Sound/Tidal/Version.hs
+++ b/src/Sound/Tidal/Version.hs
@@ -1,4 +1,4 @@
 module Sound.Tidal.Version where
 
 tidal_version :: String
-tidal_version = "1.2.1"
+tidal_version = "1.4.0"

--- a/test/Sound/Tidal/CoreTest.hs
+++ b/test/Sound/Tidal/CoreTest.hs
@@ -105,14 +105,14 @@ run =
         (map value $ queryArc ((+1) <$> saw) (Arc 0.5 0.5)) `shouldBe` [1.5 :: Float]
       it "works on the left of <*>" $ do
         (queryArc ((+) <$> saw <*> pure 3) (Arc 0 1))
-          `shouldBe` fmap toEvent [(((0,1), (0,1)), 3.5 :: Float)]
+          `shouldBe` [Event Nothing (Arc 0 1) 3.5]
       it "works on the right of <*>" $ do
         (queryArc ((fast 4 $ pure (+3)) <*> saw) (Arc 0 1))
-          `shouldBe` fmap toEvent
-          [(((0,0.25), (0,0.25)), 3.125 :: Float),
-            (((0.25,0.5), (0.25,0.5)), 3.375),
-            (((0.5,0.75), (0.5,0.75)), 3.625),
-            (((0.75,1), (0.75,1)), 3.875)
+          `shouldBe` 
+          [Event Nothing (Arc 0 0.25) 3.5,
+           Event Nothing (Arc 0.25 0.5) 3.5,
+           Event Nothing (Arc 0.5 0.75) 3.5,
+           Event Nothing (Arc 0.75 1) 3.5
           ]
       it "can be reversed" $ do
         it "works with whole cycles" $

--- a/test/Sound/Tidal/CoreTest.hs
+++ b/test/Sound/Tidal/CoreTest.hs
@@ -94,13 +94,13 @@ run =
     describe "saw" $ do
       it "goes from 0 up to 1 every cycle" $ do
         it "0" $
-          (queryArc saw (Arc 0 0))    `shouldBe` fmap toEvent [(((0,0), (0,0)),    0 :: Float)]
+          (queryArc saw (Arc 0 0)) `shouldBe` [(Event Nothing (Arc 0 0) 0)]
         it "0.25" $
-          (queryArc saw (Arc 0.25 0.25)) `shouldBe` fmap toEvent [(((0.25,0.25), (0.25,0.25)), 0.25 :: Float)]
+          (queryArc saw (Arc 0.25 0.25)) `shouldBe` [(Event Nothing (Arc 0.25 0.25) 0.25)]
         it "0.5" $
-          (queryArc saw (Arc 0.5 0.5))  `shouldBe` fmap toEvent [(((0.5,0.5), (0.5,0.5) ), 0.5 :: Float)]
+          (queryArc saw (Arc 0.5 0.5))  `shouldBe` [(Event Nothing (Arc 0.5 0.5) 0.5)]
         it "0.75" $
-          (queryArc saw (Arc 0.75 0.75)) `shouldBe` fmap toEvent [(((0.75,0.75), (0.75,0.75)), 0.75 :: Float)]
+          (queryArc saw (Arc 0.75 0.75)) `shouldBe` [(Event Nothing (Arc 0.75 0.75) 0.75)]
       it "can be added to" $ do
         (map value $ queryArc ((+1) <$> saw) (Arc 0.5 0.5)) `shouldBe` [1.5 :: Float]
       it "works on the left of <*>" $ do
@@ -117,13 +117,13 @@ run =
       it "can be reversed" $ do
         it "works with whole cycles" $
           (queryArc (rev saw) (Arc 0 1))
-            `shouldBe` fmap toEvent [(((0,1), (0,1)), 0.5 :: Float)]
+            `shouldBe` [(Event Nothing (Arc 0 1) 0.5)]
         it "works with half cycles" $
           (queryArc (rev saw) (Arc 0 0.5))
-            `shouldBe` fmap toEvent [(((0,0.5), (0,0.5)), 0.75 :: Float)]
+            `shouldBe` [(Event Nothing (Arc 0 0.5) 0.75)]
         it "works with inset points" $
           (queryArc (rev saw) (Arc 0.25 0.25))
-            `shouldBe` fmap toEvent [(((0.25,0.25), (0.25,0.25)), 0.75 :: Float)]
+            `shouldBe` [(Event Nothing (Arc 0.25 0.25) 0.75)]
 
     describe "tri" $ do
       it "goes from 0 up to 1 and back every cycle" $ do

--- a/test/Sound/Tidal/PatternTest.hs
+++ b/test/Sound/Tidal/PatternTest.hs
@@ -25,53 +25,54 @@ run =
         let res = fmap (+1) (Arc 3 5)
         property $ ((Arc 4 6) :: Arc) === res
 
+  {-
     describe "Event" $ do
       it "(Bifunctor) first: Apply a function to the Arc elements: whole and part" $ do
-        let res = Event (Arc 1 2) (Arc 3 4) 5 :: Event Int
+        let res = Event (Just $ Arc 1 2) (Arc 3 4) 5 :: Event Int
             f = (+1)
         property $
           first f res ===
-          Event (Arc 2 3) (Arc 4 5) 5
+          Event (Just $ Arc 2 3) (Arc 4 5) 5
       it "(Bifunctor) second: Apply a function to the event element" $ do
-        let res = Event (Arc 1 2) (Arc 3 4) 5 :: Event Int
+        let res = Event (Just $ Arc 1 2) (Arc 3 4) 5 :: Event Int
             f = (+1)
         property $
           second f res ===
-          Event (Arc 1 2) (Arc 3 4) 6
+          Event (Just $ Arc 1 2) (Arc 3 4) 6-}
 
     describe "whole" $ do
       it "returns the whole Arc in an Event" $ do
-        property $ Arc 1 2 === whole (Event (Arc 1 2) (Arc 3 4) 5 :: Event Int)
+        property $ (Just $ Arc 1 2) === whole (Event (Just $ Arc 1 2) (Arc 3 4) 5 :: Event Int)
 
     describe "part" $ do
       it "returns the part Arc in an Event" $ do
-        property $ Arc 3 4 === part (Event (Arc 1 2) (Arc 3 4) 5 :: Event Int)
+        property $ (Arc 3 4) === part (Event (Just $ Arc 1 2) (Arc 3 4) 5 :: Event Int)
 
     describe "value" $ do
       it "returns the event value in an Event" $ do
-        property $ 5 === value (Event (Arc 1 2 :: Arc) (Arc 3 4) ( 5 :: Int))
+        property $ 5 === value (Event (Just $ Arc 1 2) (Arc 3 4) ( 5 :: Int))
 
     describe "wholeStart" $ do 
       it "retrieve the onset of an event: the start of the whole Arc" $ do 
-        property $ 1 === wholeStart (Event (Arc 1 2) (Arc 3 4) (5 :: Int))
+        property $ 1 === wholeStart (Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int))
 
     describe "eventHasOnset" $ do 
       it "return True when the start values of the two arcs in an event are equal" $ do 
-        let ev = (Event (Arc 1 2) (Arc 1 3) (4 :: Int)) 
+        let ev = (Event (Just $ Arc 1 2) (Arc 1 3) (4 :: Int)) 
         property $ True === eventHasOnset ev 
       it "return False when the start values of the two arcs in an event are not equal" $ do 
-        let ev = (Event (Arc 1 2) (Arc 3 4) (5 :: Int)) 
+        let ev = (Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int)) 
         property $ False === eventHasOnset ev
 
     describe "pure" $ do
       it "fills a whole cycle" $ do
-        property $ queryArc (pure 0) (Arc 0 1) === [(Event (Arc 0 1) (Arc 0 1) (0 :: Int))]
+        property $ queryArc (pure 0) (Arc 0 1) === [(Event (Just $ Arc 0 1) (Arc 0 1) (0 :: Int))]
       it "returns the part of an pure that you ask for, preserving the whole" $ do
-        property $ queryArc (pure 0) (Arc 0.25 0.75) === [(Event (Arc 0 1) (Arc 0.25 0.75) (0 :: Int))]
+        property $ queryArc (pure 0) (Arc 0.25 0.75) === [(Event (Just $ Arc 0 1) (Arc 0.25 0.75) (0 :: Int))]
       it "gives correct fragments when you go over cycle boundaries" $ do
         property $ queryArc (pure 0) (Arc 0.25 1.25) ===
-          [ (Event (Arc 0 1) (Arc 0.25 1) (0 :: Int)),
-            (Event (Arc 1 2) (Arc 1 1.25) 0)
+          [ (Event (Just $ Arc 0 1) (Arc 0.25 1) (0 :: Int)),
+            (Event (Just $ Arc 1 2) (Arc 1 1.25) 0)
           ]
       it "works with zero-length queries" $ do
         it "0" $
@@ -85,8 +86,8 @@ run =
       it "copes with cross-cycle queries" $ do
         (queryArc(_fastGap 2 $ fastCat [pure "a", pure "b"]) (Arc 0.5 1.5))
           `shouldBe`
-          [(Event (Arc (1 % 1) (5 % 4)) (Arc (1 % 1) (5 % 4)) ("a" :: String)),
-           (Event (Arc (5 % 4) (3 % 2)) (Arc (5 % 4) (3 % 2)) "b")
+          [(Event (Just $ Arc (1 % 1) (5 % 4)) (Arc (1 % 1) (5 % 4)) ("a" :: String)),
+           (Event (Just $ Arc (5 % 4) (3 % 2)) (Arc (5 % 4) (3 % 2)) "b")
           ]
       it "does not return events outside of the query" $ do
         (queryArc(_fastGap 2 $ fastCat [pure "a", pure ("b" :: String)]) (Arc 0.5 0.9))
@@ -191,9 +192,9 @@ run =
             b = fastCat [pure "c", pure "d", pure "e"]
             pp = fastCat [pure a, pure b]
         queryArc (unwrap pp) (Arc 0 1)
-          `shouldBe` [(Event (Arc (0 % 1) (1 % 2)) (Arc (0 % 1) (1 % 2)) ("a" :: String)),
-                      (Event (Arc (1 % 2) (2 % 3)) (Arc (1 % 2) (2 % 3)) "d"),
-                      (Event (Arc (2 % 3) (1 % 1)) (Arc (2 % 3) (1 % 1)) "e")
+          `shouldBe` [(Event (Just $ Arc (0 % 1) (1 % 2)) (Arc (0 % 1) (1 % 2)) ("a" :: String)),
+                      (Event (Just $ Arc (1 % 2) (2 % 3)) (Arc (1 % 2) (2 % 3)) "d"),
+                      (Event (Just $ Arc (2 % 3) (1 % 1)) (Arc (2 % 3) (1 % 1)) "e")
                      ]
 
     describe "squeezeJoin" $ do
@@ -202,11 +203,11 @@ run =
             b = fastCat [pure "c", pure "d", pure "e"]
             pp = fastCat [pure a, pure b]
         queryArc (squeezeJoin pp) (Arc 0 1)
-          `shouldBe` [(Event (Arc (0 % 1) (1 % 4)) (Arc (0 % 1) (1 % 4)) ("a" :: String)),
-                      (Event (Arc (1 % 4) (1 % 2)) (Arc (1 % 4) (1 % 2)) "b"),
-                      (Event (Arc (1 % 2) (2 % 3)) (Arc (1 % 2) (2 % 3)) "c"),
-                      (Event (Arc (2 % 3) (5 % 6)) (Arc (2 % 3) (5 % 6)) "d"),
-                      (Event (Arc (5 % 6) (1 % 1)) (Arc (5 % 6) (1 % 1)) "e")
+          `shouldBe` [(Event (Just $ Arc (0 % 1) (1 % 4)) (Arc (0 % 1) (1 % 4)) ("a" :: String)),
+                      (Event (Just $ Arc (1 % 4) (1 % 2)) (Arc (1 % 4) (1 % 2)) "b"),
+                      (Event (Just $ Arc (1 % 2) (2 % 3)) (Arc (1 % 2) (2 % 3)) "c"),
+                      (Event (Just $ Arc (2 % 3) (5 % 6)) (Arc (2 % 3) (5 % 6)) "d"),
+                      (Event (Just $ Arc (5 % 6) (1 % 1)) (Arc (5 % 6) (1 % 1)) "e")
                      ]
 
     describe ">>=" $ do
@@ -251,38 +252,38 @@ run =
     describe "controlI" $ do
       it "can retrieve values from state" $
        (query (pure 3 + cF_ "hello") $ State (Arc 0 1) (Map.singleton "hello" (pure $ VF 0.5)))
-       `shouldBe` [(Event (Arc (0 % 1) (1 % 1)) (Arc (0 % 1) (1 % 1)) 3.5)]
+       `shouldBe` [(Event (Just $ Arc (0 % 1) (1 % 1)) (Arc (0 % 1) (1 % 1)) 3.5)]
 
     describe "wholeStart" $ do 
       it "retrieve first element of a tuple, inside first element of a tuple, inside the first of another" $ do 
-        property $ 1 === wholeStart (Event (Arc 1 2) (Arc 3 4) (5 :: Int))
+        property $ 1 === wholeStart (Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int))
 
     describe "wholeStop" $ do
       it "retrieve the end time from the first Arc in an Event" $ do
-        property $ 2 === wholeStop (Event (Arc 1 2) (Arc 3 4) (5 :: Int))
+        property $ 2 === wholeStop (Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int))
 
     describe "eventPartStart" $ do 
       it "retrieve the start time of the second Arc in an Event" $ do 
-        property $ 3 === eventPartStart (Event (Arc 1 2) (Arc 3 4) (5 :: Int))
+        property $ 3 === eventPartStart (Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int))
 
     describe "eventPartStop" $ do 
       it "retrieve the end time of the second Arc in an Event" $ do 
-        property $ 4 === eventPartStop (Event (Arc 1 2) (Arc 3 4) (5 :: Int))
+        property $ 4 === eventPartStop (Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int))
     
     describe "eventPart" $ do 
       it "retrieve the second Arc in an Event" $ do 
-        property $ Arc 3 4 === eventPart (Event (Arc 1 2) (Arc 3 4) (5 :: Int))
+        property $ Arc 3 4 === eventPart (Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int))
     
     describe "eventValue" $ do
       it "retrieve the second value from a tuple" $ do 
-        property $ 5 === eventValue (Event (Arc 1 2) (Arc 3 4) (5 :: Int))
+        property $ 5 === eventValue (Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int))
 
     describe "eventHasOnset" $ do 
       it "return True when the start values of the two arcs in an event are equal" $ do 
-        let ev = (Event (Arc 1 2) (Arc 1 3) (4 :: Int)) 
+        let ev = (Event (Just $ Arc 1 2) (Arc 1 3) (4 :: Int)) 
         property $ True === eventHasOnset ev 
       it "return False when the start values of the two arcs in an event are not equal" $ do 
-        let ev = (Event (Arc 1 2) (Arc 3 4) (5 :: Int)) 
+        let ev = (Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int)) 
         property $ False === eventHasOnset ev
 
     describe "sam" $ do
@@ -360,16 +361,16 @@ run =
 
     describe "onsetIn" $ do
       it "If the beginning of an Event is within a given Arc, same rules as 'isIn'" $ do 
-         let res = onsetIn (Arc 2.0 2.8) (Event (Arc 2.2 2.7) (Arc 3.3 3.8) (5 :: Int))
+         let res = onsetIn (Arc 2.0 2.8) (Event (Just $ Arc 2.2 2.7) (Arc 3.3 3.8) (5 :: Int))
          property $ True === res 
       it "Beginning of Event is equal to beggining of given Arc" $ do 
-         let res = onsetIn (Arc 2.0 2.8) (Event (Arc 2.0 2.7) (Arc 3.3 3.8) (5 :: Int))
+         let res = onsetIn (Arc 2.0 2.8) (Event (Just $ Arc 2.0 2.7) (Arc 3.3 3.8) (5 :: Int))
          property $ True === res 
       it "Beginning of an Event is less than the start of the Arc" $ do 
-         let res = onsetIn (Arc 2.0 2.8) (Event (Arc 1.2 1.7) (Arc 3.3 3.8) (5 :: Int))
+         let res = onsetIn (Arc 2.0 2.8) (Event (Just $ Arc 1.2 1.7) (Arc 3.3 3.8) (5 :: Int))
          property $ False === res
       it "Start of Event is greater than the start of the given Arc" $ do 
-         let res = onsetIn (Arc 2.0 2.8) (Event (Arc 3.1 3.5) (Arc 4.0 4.6) (5 :: Int))
+         let res = onsetIn (Arc 2.0 2.8) (Event (Just $ Arc 3.1 3.5) (Arc 4.0 4.6) (5 :: Int))
          property $ False === res
 
     describe "subArc" $ do
@@ -403,16 +404,16 @@ run =
 
     describe "isAdjacent" $ do
       it "if the given Events are adjacent parts of the same whole" $ do 
-        let res = isAdjacent (Event (Arc 1 2) (Arc 3 4) 5) (Event (Arc 1 2) (Arc 4 3) (5 :: Int))
+        let res = isAdjacent (Event (Just $ Arc 1 2) (Arc 3 4) 5) (Event (Just $ Arc 1 2) (Arc 4 3) (5 :: Int))
         property $ True === res 
       it "if first Arc of of first Event is not equal to first Arc of second Event" $ do
-        let res = isAdjacent (Event (Arc 1 2) (Arc 3 4) 5) (Event (Arc 7 8) (Arc 4 3) (5 :: Int))
+        let res = isAdjacent (Event (Just $ Arc 1 2) (Arc 3 4) 5) (Event (Just $ Arc 7 8) (Arc 4 3) (5 :: Int))
         property $ False === res  
       it "if the value of the first Event does not equal the value of the second Event" $ do 
-        let res = isAdjacent (Event (Arc 1 2) (Arc 3 4) 5) (Event (Arc 1 2) (Arc 4 3) (6 :: Int))
+        let res = isAdjacent (Event (Just $ Arc 1 2) (Arc 3 4) 5) (Event (Just $ Arc 1 2) (Arc 4 3) (6 :: Int))
         property $ False === res 
       it "second value of second Arc of first Event not equal to first value of second Arc in second Event..." $ do
-        let res = isAdjacent (Event (Arc 1 2) (Arc 3 4) 5) (Event (Arc 1 2) (Arc 3 4) (5 :: Int))
+        let res = isAdjacent (Event (Just $ Arc 1 2) (Arc 3 4) 5) (Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int))
         property $ False === res 
 
     describe "defragParts" $ do 
@@ -420,24 +421,24 @@ run =
         let res = defragParts ([] :: [Event Int]) 
         property $ [] === res
       it "if list consists of only one Event return it as is" $ do 
-        let res = defragParts [(Event (Arc 1 2) (Arc 3 4) (5 :: Int))]
-        property $ [Event (Arc 1 2) (Arc 3 4) (5 :: Int)] === res 
+        let res = defragParts [(Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int))]
+        property $ [Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int)] === res 
       it "if list contains adjacent Events return list with Parts combined" $ do 
-        let res = defragParts [(Event (Arc 1 2) (Arc 3 4) (5 :: Int)), (Event (Arc 1 2) (Arc 4 3) (5 :: Int))]
-        property $ [(Event (Arc 1 2) (Arc 3 4) 5)] === res
+        let res = defragParts [(Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int)), (Event (Just $ Arc 1 2) (Arc 4 3) (5 :: Int))]
+        property $ [(Event (Just $ Arc 1 2) (Arc 3 4) 5)] === res
       it "if list contains more than one Event none of which are adjacent, return List as is" $ do 
-        let res = defragParts [(Event (Arc 1 2) (Arc 3 4) 5), (Event (Arc 7 8) (Arc 4 3) (5 :: Int))]
-        property $ [Event (Arc 1 2) (Arc 3 4) 5, Event (Arc 7 8) (Arc 4 3) (5 :: Int)] === res
+        let res = defragParts [(Event (Just $ Arc 1 2) (Arc 3 4) 5), (Event (Just $ Arc 7 8) (Arc 4 3) (5 :: Int))]
+        property $ [Event (Just $ Arc 1 2) (Arc 3 4) 5, Event (Just $ Arc 7 8) (Arc 4 3) (5 :: Int)] === res
 
     describe "compareDefrag" $ do 
       it "compare list with Events with empty list of Events" $ do
-        let res = compareDefrag [Event (Arc 1 2) (Arc 3 4) (5 :: Int), Event (Arc 1 2) (Arc 4 3) (5 :: Int)] []
+        let res = compareDefrag [Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int), Event (Just $ Arc 1 2) (Arc 4 3) (5 :: Int)] []
         property $ False === res 
       it "compare lists containing same Events but of different length" $ do 
-        let res = compareDefrag [Event (Arc 1 2) (Arc 3 4) (5 :: Int), Event (Arc 1 2) (Arc 4 3) 5] [Event (Arc 1 2) (Arc 3 4) (5 :: Int)]
+        let res = compareDefrag [Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int), Event (Just $ Arc 1 2) (Arc 4 3) 5] [Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int)]
         property $ True === res
       it "compare lists of same length with same Events" $ do 
-        let res = compareDefrag [Event (Arc 1 2) (Arc 3 4) (5 :: Int)] [Event (Arc 1 2) (Arc 3 4) (5 :: Int)]
+        let res = compareDefrag [Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int)] [Event (Just $ Arc 1 2) (Arc 3 4) (5 :: Int)]
         property $ True === res 
 
     describe "sect" $ do 
@@ -549,8 +550,8 @@ run =
 
     -- pending "Sound.Tidal.Pattern.eventL" $ do
     --  it "succeeds if the first event 'whole' is shorter" $ do
-    --    property $ eventL (Event (Arc 0,0),(Arc 0 1)),"x") (((0 0) (Arc 0 1.1)) "x")
+    --    property $ eventL (Event (Just $ Arc 0,0),(Arc 0 1)),"x") (((0 0) (Arc 0 1.1)) "x")
     --  it "fails if the events are the same length" $ do
-    --    property $ not $ eventL (Event (Arc 0,0),(Arc 0 1)),"x") (((0 0) (Arc 0 1)) "x")
+    --    property $ not $ eventL (Event (Just $ Arc 0,0),(Arc 0 1)),"x") (((0 0) (Arc 0 1)) "x")
     --  it "fails if the second event is shorter" $ do
-    --    property $ not $ eventL (Event (Arc 0,0),(Arc 0 1)),"x") (((0 0) (Arc 0 0.5)) "x")
+    --    property $ not $ eventL (Event (Just $ Arc 0,0),(Arc 0 1)),"x") (((0 0) (Arc 0 0.5)) "x")

--- a/test/Sound/Tidal/UITest.hs
+++ b/test/Sound/Tidal/UITest.hs
@@ -104,26 +104,26 @@ run =
 
         describe "from -1 to 1" $ do
           it "at 1/2 of a cycle" $
-            (queryArc (Sound.Tidal.UI.range (-1) 1 saw) (Arc 0.5 0.5)) `shouldBe` fmap toEvent
-              [(((0.5, 0.5), (0.5, 0.5)), 0 :: Float)]
+            (queryArc (Sound.Tidal.UI.range (-1) 1 saw) (Arc 0.5 0.5)) `shouldBe`
+              [Event Nothing (Arc 0.5 0.5) (0 :: Float)]
 
         describe "from 4 to 2" $ do
           it "at the start of a cycle" $
-            (queryArc (Sound.Tidal.UI.range 4 2 saw) (Arc 0 0)) `shouldBe` fmap toEvent
-              [(((0, 0), (0, 0)), 4 :: Float)]
+            (queryArc (Sound.Tidal.UI.range 4 2 saw) (Arc 0 0)) `shouldBe` 
+              [Event Nothing (Arc 0 0) (4 :: Float)]
           it "at 1/4 of a cycle" $
-            (queryArc (Sound.Tidal.UI.range 4 2 saw) (Arc 0.25 0.25)) `shouldBe` fmap toEvent
-              [(((0.25, 0.25), (0.25, 0.25)), 3.5 :: Float)]
+            (queryArc (Sound.Tidal.UI.range 4 2 saw) (Arc 0.25 0.25)) `shouldBe` 
+              [Event Nothing (Arc 0.25 0.25) (3.5 :: Float)]
           it "at 3/4 of a cycle" $
-            (queryArc (Sound.Tidal.UI.range 4 2 saw) (Arc 0.75 0.75)) `shouldBe` fmap toEvent
-              [(((0.75, 0.75), (0.75, 0.75)), 2.5 :: Float)]
+            (queryArc (Sound.Tidal.UI.range 4 2 saw) (Arc 0.75 0.75)) `shouldBe` 
+              [Event Nothing (Arc 0.75 0.75) (2.5 :: Float)]
 
         describe "from 10 to 10" $ do
           it "at 1/2 of a cycle" $
-            (queryArc (Sound.Tidal.UI.range 10 10 saw) (Arc 0.5 0.5)) `shouldBe` fmap toEvent
-              [(((0.5, 0.5), (0.5, 0.5)), 10 :: Float)]
+            (queryArc (Sound.Tidal.UI.range 10 10 saw) (Arc 0.5 0.5)) `shouldBe` 
+              [Event Nothing (Arc 0.5 0.5) (10 :: Float)]
 
-    describe "rot" $ do
+    describe "rot" $ do 
       it "rotates values in a pattern irrespective of structure" $
         property $ comparePD (Arc 0 2)
           (rot 1 "a ~ b c" :: Pattern String)

--- a/test/Sound/Tidal/UITest.hs
+++ b/test/Sound/Tidal/UITest.hs
@@ -81,26 +81,26 @@ run =
     describe "rand" $ do
       it "generates a (pseudo-)random number between zero & one" $ do
         it "at the start of a cycle" $
-          (queryArc rand (Arc 0 0)) `shouldBe` fmap toEvent [(((0, 0), (0, 0)), 0.5000844 :: Float)]
+          (queryArc rand (Arc 0 0)) `shouldBe` [Event Nothing (Arc 0 0) (0.5000844 :: Float)]
         it "at 1/4 of a cycle" $
-          (queryArc rand (Arc 0.25 0.25)) `shouldBe` fmap toEvent
-            [(((0.25, 0.25), (0.25, 0.25)), 0.8587171 :: Float)]
+          (queryArc rand (Arc 0.25 0.25)) `shouldBe` 
+            [Event Nothing (Arc 0.25 0.25) (0.8587171 :: Float)]
         it "at 3/4 of a cycle" $
-          (queryArc rand (Arc 0.75 0.75)) `shouldBe` fmap toEvent
-            [(((0.75, 0.75), (0.75, 0.75)), 0.7277789 :: Float)]
+          (queryArc rand (Arc 0.75 0.75)) `shouldBe` 
+          [Event Nothing (Arc 0.75 0.75) (0.7277789 :: Float)]
 
     describe "range" $ do
       describe "scales a pattern to the supplied range" $ do
         describe "from 3 to 4" $ do
           it "at the start of a cycle" $
-            (queryArc (Sound.Tidal.UI.range 3 4 saw) (Arc 0 0)) `shouldBe` fmap toEvent
-              [(((0, 0), (0, 0)), 3 :: Float)]
+            (queryArc (Sound.Tidal.UI.range 3 4 saw) (Arc 0 0)) `shouldBe` 
+              [Event Nothing (Arc 0 0) (3 :: Float)]
           it "at 1/4 of a cycle" $
-            (queryArc (Sound.Tidal.UI.range 3 4 saw) (Arc 0.25  0.25)) `shouldBe` fmap toEvent
-              [(((0.25, 0.25), (0.25, 0.25)), 3.25 :: Float)]
+            (queryArc (Sound.Tidal.UI.range 3 4 saw) (Arc 0.25  0.25)) `shouldBe`
+              [Event Nothing (Arc 0.25 0.25) (3.25 :: Float)]
           it "at 3/4 of a cycle" $
-            (queryArc (Sound.Tidal.UI.range 3 4 saw) (Arc 0.75 0.75)) `shouldBe` fmap toEvent
-              [(((0.75, 0.75), (0.75, 0.75)), 3.75 :: Float)]
+            (queryArc (Sound.Tidal.UI.range 3 4 saw) (Arc 0.75 0.75)) `shouldBe` 
+              [Event Nothing (Arc 0.75 0.75) (3.75 :: Float)]
 
         describe "from -1 to 1" $ do
           it "at 1/2 of a cycle" $

--- a/tidal.cabal
+++ b/tidal.cabal
@@ -1,5 +1,5 @@
 name:                tidal
-version:             1.2.0
+version:             1.4.0
 synopsis:            Pattern language for improvised music
 -- description:
 homepage:            http://tidalcycles.org/


### PR DESCRIPTION
Fixes #543, by wrapping the 'whole' in a maybe - the idea being that continuous events don't have wholes.

I had to do some reworking of `<*>`, `<*` and `*>` in the process.

If you combine a continuous event with a discrete one, you get a continuous one back.. So e.g. `sine + 1` is the same as `range 1 2 sine`.
 
If you really want to use the discrete pattern to sample a continuous one you can use `<*` or `*>`, e.g. via `sine +| 1`.

Because it's events rather than patterns that are discrete, you can do this:
  `(stack [saw, 1]) + 1` 

The `Show` instance denotes continuous events with `~`s, e.g.:

```
~0>1~|1.5
(0>1)|2.0
```

`~0>1~|1.5` means that a continuous event was sampled with `(Arc 0 1)`, and the value `1.5` (being the value at the midpoint of 0.5) was returned.

This:
```
("2 3" + saw) :: Pattern Double
```
Now gives this:
```
~0>½~|2.5
~½>1~|3.5
```
This is because the `saw` is being sampled with the default arc of `Arc 0 1`, the midpoint of `0.5` is found then added to both `2` and `3`. Querying the same pattern with a different arc gives a different answer:
```
queryArc (("2 3" + saw) :: Pattern Double) (Arc 0 0.5)
[~0>½~|2.25]
```
If you want to sample from a continuous pattern using a discrete one you have to be explicit about it, e.g. with `|+`:
```
"2 3" |+ saw :: Pattern Double
```
Giving:
```
(0>½)|2.25
(½>1)|3.75
```
I think this is all making some sense now. However there are probably bugs to be found!