### PR TITLE
Build emacs tidal boot path in more cross platform way

### DIFF
--- a/tidal.el
+++ b/tidal.el
@@ -58,12 +58,22 @@
   "*Arguments to the haskell interpreter (default=none).")
 
 (defvar tidal-boot-script-path
-  (concat (substring
-           (shell-command-to-string
-            "ghc-pkg describe $(ghc-pkg latest tidal) | grep data-dir | cut -f2 -d' '") 0 -1)
-          "/BootTidal.hs")
-  "*Full path to BootTidal.hs (inferred by introspecting ghc-pkg package db)."
+  (let ((filepath
+         (cond
+          ((string-equal system-type "windows-nt")
+           '(("path" . "echo off && for /f %a in ('ghc-pkg latest tidal') do (for /f \"tokens=2\" %i in ('ghc-pkg describe %a ^| findstr data-dir') do (echo %i))")
+             ("separator" . "\\")
+             ))
+          ((or (string-equal system-type "darwin") (string-equal system-type "gnu/linux"))
+           '(("path" . "ghc-pkg describe $(ghc-pkg latest tidal) | grep data-dir | cut -f2 -d' '")
+             ("separator" . "/")
+             ))
+          )
+         ))
+    (concat (substring (shell-command-to-string (cdr (assoc "path" filepath))) 0 -1) (cdr (assoc "separator" filepath)) "BootTidal.hs")
   )
+  "*Full path to BootTidal.hs (inferred by introspecting ghc-pkg package db)."
+)
 
 (defvar tidal-literate-p
   t


### PR DESCRIPTION
👋 Nice to meet you! My first Tidal PR. 
I've read the contributing and code of conduct docs, and I think I've done everything correctly, but let me know if there's anything amiss.
This PR:
Build tidal boot path in more cross platform way
Previously Windows platforms were not handled. This change allows the BootTidal
script to be found there also.

I'm fairly new when it comes to lisp/elisp, (and windows cmd/batch file programming for that matter) so the code in this PR may not be the same as some written by someone more experienced with it; I'm happy to take on board any comments anyone may have 🙂 

### Testing:
I have the Tidal code checked out locally on both Windows and macOS computers. I started Tidal from emacs in both of them using the code in this change successfully.