### PR TITLE
Support fractional scales and add Arabic scales

### DIFF
--- a/src/Sound/Tidal/Scales.hs
+++ b/src/Sound/Tidal/Scales.hs
@@ -6,181 +6,182 @@ import Sound.Tidal.Pattern
 import Sound.Tidal.Utils
 
 -- five notes scales
-minPent :: Num a => [a]
+minPent :: Fractional a => [a]
 minPent = [0,3,5,7,10]
-majPent :: Num a => [a]
+majPent :: Fractional a => [a]
 majPent = [0,2,4,7,9]
 
 --  another mode of major pentatonic
-ritusen :: Num a => [a]
+ritusen :: Fractional a => [a]
 ritusen = [0,2,5,7,9]
 
 -- another mode of major pentatonic
-egyptian :: Num a => [a]
+egyptian :: Fractional a => [a]
 egyptian = [0,2,5,7,10]
 
 --
-kumai :: Num a => [a]
+kumai :: Fractional a => [a]
 kumai = [0,2,3,7,9]
-hirajoshi :: Num a => [a]
+hirajoshi :: Fractional a => [a]
 hirajoshi = [0,2,3,7,8]
-iwato :: Num a => [a]
+iwato :: Fractional a => [a]
 iwato = [0,1,5,6,10]
-chinese :: Num a => [a]
+chinese :: Fractional a => [a]
 chinese = [0,4,6,7,11]
-indian :: Num a => [a]
+indian :: Fractional a => [a]
 indian = [0,4,5,7,10]
-pelog :: Num a => [a]
+pelog :: Fractional a => [a]
 pelog = [0,1,3,7,8]
 
 --
-prometheus :: Num a => [a]
+prometheus :: Fractional a => [a]
 prometheus = [0,2,4,6,11]
-scriabin :: Num a => [a]
+scriabin :: Fractional a => [a]
 scriabin = [0,1,4,7,9]
 
 -- han chinese pentatonic scales
-gong :: Num a => [a]
+gong :: Fractional a => [a]
 gong = [0,2,4,7,9]
-shang :: Num a => [a]
+shang :: Fractional a => [a]
 shang = [0,2,5,7,10]
-jiao :: Num a => [a]
+jiao :: Fractional a => [a]
 jiao = [0,3,5,8,10]
-zhi :: Num a => [a]
+zhi :: Fractional a => [a]
 zhi = [0,2,5,7,9]
-yu :: Num a => [a]
+yu :: Fractional a => [a]
 yu = [0,3,5,7,10]
 
 -- 6 note scales
-whole' :: Num a => [a]
+whole' :: Fractional a => [a]
 whole' = [0,2,4,6,8,10]
-augmented :: Num a => [a]
+augmented :: Fractional a => [a]
 augmented = [0,3,4,7,8,11]
-augmented2 :: Num a => [a]
+augmented2 :: Fractional a => [a]
 augmented2 = [0,1,4,5,8,9]
 
 -- hexatonic modes with no tritone
-hexMajor7 :: Num a => [a]
+hexMajor7 :: Fractional a => [a]
 hexMajor7 = [0,2,4,7,9,11]
-hexDorian :: Num a => [a]
+hexDorian :: Fractional a => [a]
 hexDorian = [0,2,3,5,7,10]
-hexPhrygian :: Num a => [a]
+hexPhrygian :: Fractional a => [a]
 hexPhrygian = [0,1,3,5,8,10]
-hexSus :: Num a => [a]
+hexSus :: Fractional a => [a]
 hexSus = [0,2,5,7,9,10]
-hexMajor6 :: Num a => [a]
+hexMajor6 :: Fractional a => [a]
 hexMajor6 = [0,2,4,5,7,9]
-hexAeolian :: Num a => [a]
+hexAeolian :: Fractional a => [a]
 hexAeolian = [0,3,5,7,8,10]
 
 -- 7 note scales
-major :: Num a => [a]
+major :: Fractional a => [a]
 major = [0,2,4,5,7,9,11]
-ionian :: Num a => [a]
+ionian :: Fractional a => [a]
 ionian = [0,2,4,5,7,9,11]
-dorian :: Num a => [a]
+dorian :: Fractional a => [a]
 dorian = [0,2,3,5,7,9,10]
-phrygian :: Num a => [a]
+phrygian :: Fractional a => [a]
 phrygian = [0,1,3,5,7,8,10]
-lydian :: Num a => [a]
+lydian :: Fractional a => [a]
 lydian = [0,2,4,6,7,9,11]
-mixolydian :: Num a => [a]
+mixolydian :: Fractional a => [a]
 mixolydian = [0,2,4,5,7,9,10]
-aeolian :: Num a => [a]
+aeolian :: Fractional a => [a]
 aeolian = [0,2,3,5,7,8,10]
-minor :: Num a => [a]
+minor :: Fractional a => [a]
 minor = [0,2,3,5,7,8,10]
-locrian :: Num a => [a]
+locrian :: Fractional a => [a]
 locrian = [0,1,3,5,6,8,10]
-harmonicMinor :: Num a => [a]
+harmonicMinor :: Fractional a => [a]
 harmonicMinor = [0,2,3,5,7,8,11]
-harmonicMajor :: Num a => [a]
+harmonicMajor :: Fractional a => [a]
 harmonicMajor = [0,2,4,5,7,8,11]
-melodicMinor :: Num a => [a]
+melodicMinor :: Fractional a => [a]
 melodicMinor = [0,2,3,5,7,9,11]
-melodicMinorDesc :: Num a => [a]
+melodicMinorDesc :: Fractional a => [a]
 melodicMinorDesc = [0,2,3,5,7,8,10]
-melodicMajor :: Num a => [a]
+melodicMajor :: Fractional a => [a]
 melodicMajor = [0,2,4,5,7,8,10]
-bartok :: Num a => [a]
+bartok :: Fractional a => [a]
 bartok = melodicMajor
-hindu :: Num a => [a]
+hindu :: Fractional a => [a]
 hindu = melodicMajor
 
 -- raga modes
-todi :: Num a => [a]
+todi :: Fractional a => [a]
 todi = [0,1,3,6,7,8,11]
-purvi :: Num a => [a]
+purvi :: Fractional a => [a]
 purvi = [0,1,4,6,7,8,11]
-marva :: Num a => [a]
+marva :: Fractional a => [a]
 marva = [0,1,4,6,7,9,11]
-bhairav :: Num a => [a]
+bhairav :: Fractional a => [a]
 bhairav = [0,1,4,5,7,8,11]
-ahirbhairav :: Num a => [a]
+ahirbhairav :: Fractional a => [a]
 ahirbhairav = [0,1,4,5,7,9,10]
 
 --
-superLocrian :: Num a => [a]
+superLocrian :: Fractional a => [a]
 superLocrian = [0,1,3,4,6,8,10]
-romanianMinor :: Num a => [a]
+romanianMinor :: Fractional a => [a]
 romanianMinor = [0,2,3,6,7,9,10]
-hungarianMinor :: Num a => [a]
+hungarianMinor :: Fractional a => [a]
 hungarianMinor = [0,2,3,6,7,8,11]
-neapolitanMinor :: Num a => [a]
+neapolitanMinor :: Fractional a => [a]
 neapolitanMinor = [0,1,3,5,7,8,11]
-enigmatic :: Num a => [a]
+enigmatic :: Fractional a => [a]
 enigmatic = [0,1,4,6,8,10,11]
-spanish :: Num a => [a]
+spanish :: Fractional a => [a]
 spanish = [0,1,4,5,7,8,10]
 
 -- modes of whole tones with added note ->
-leadingWhole :: Num a => [a]
+leadingWhole :: Fractional a => [a]
 leadingWhole = [0,2,4,6,8,10,11]
-lydianMinor :: Num a => [a]
+lydianMinor :: Fractional a => [a]
 lydianMinor = [0,2,4,6,7,8,10]
-neapolitanMajor :: Num a => [a]
+neapolitanMajor :: Fractional a => [a]
 neapolitanMajor = [0,1,3,5,7,9,11]
-locrianMajor :: Num a => [a]
+locrianMajor :: Fractional a => [a]
 locrianMajor = [0,2,4,5,6,8,10]
 
 -- 8 note scales
-diminished :: Num a => [a]
+diminished :: Fractional a => [a]
 diminished = [0,1,3,4,6,7,9,10]
-diminished2 :: Num a => [a]
+diminished2 :: Fractional a => [a]
 diminished2 = [0,2,3,5,6,8,9,11]
 
 -- modes of limited transposition
-messiaen1 :: Num a => [a]
+messiaen1 :: Fractional a => [a]
 messiaen1 = whole'
-messiaen2 :: Num a => [a]
+messiaen2 :: Fractional a => [a]
 messiaen2 = diminished
-messiaen3 :: Num a => [a]
+messiaen3 :: Fractional a => [a]
 messiaen3 = [0, 2, 3, 4, 6, 7, 8, 10, 11]
-messiaen4 :: Num a => [a]
+messiaen4 :: Fractional a => [a]
 messiaen4 = [0, 1, 2, 5, 6, 7, 8, 11]
-messiaen5 :: Num a => [a]
+messiaen5 :: Fractional a => [a]
 messiaen5 = [0, 1, 5, 6, 7, 11]
-messiaen6 :: Num a => [a]
+messiaen6 :: Fractional a => [a]
 messiaen6 = [0, 2, 4, 5, 6, 8, 10, 11]
-messiaen7 :: Num a => [a]
+messiaen7 :: Fractional a => [a]
 messiaen7 = [0, 1, 2, 3, 5, 6, 7, 8, 9, 11]
 
 -- 12 note scales
-chromatic :: Num a => [a]
+chromatic :: Fractional a => [a]
 chromatic = [0,1,2,3,4,5,6,7,8,9,10,11]
 
-scale :: Num a => Pattern String -> Pattern Int -> Pattern a
+scale :: Fractional a => Pattern String -> Pattern Int -> Pattern a
 scale = getScale scaleTable
 
-getScale :: Num a => [(String, [a])] -> Pattern String -> Pattern Int -> Pattern a
-getScale table sp p = (\n scaleName -> noteInScale (fromMaybe [0] $ lookup scaleName table) n) <$> p <*> sp
+getScale :: Fractional a => [(String, [a])] -> Pattern String -> Pattern Int -> Pattern a
+getScale table sp p = (\n scaleName
+              -> noteInScale (fromMaybe [0] $ lookup scaleName table) n) <$> p <*> sp
   where octave s x = x `div` length s
         noteInScale s x = (s !!! x) + fromIntegral (12 * octave s x)
 
 scaleList :: String
-scaleList = unwords $ map fst (scaleTable :: [(String, [Int])])
+scaleList = unwords $ map fst (scaleTable :: [(String, [Rational])])
 
-scaleTable :: Num a => [(String, [a])]
+scaleTable :: Fractional a => [(String, [a])]
 scaleTable = [("minPent", minPent),
               ("majPent", majPent),
               ("ritusen", ritusen),
@@ -252,4 +253,3 @@ scaleTable = [("minPent", minPent),
               ("messiaen7", messiaen7),
               ("chromatic", chromatic)
              ]
-

--- a/src/Sound/Tidal/Scales.hs
+++ b/src/Sound/Tidal/Scales.hs
@@ -165,6 +165,20 @@ messiaen6 = [0, 2, 4, 5, 6, 8, 10, 11]
 messiaen7 :: Fractional a => [a]
 messiaen7 = [0, 1, 2, 3, 5, 6, 7, 8, 9, 11]
 
+-- Arabic maqams taken from SuperCollider's Scale.sc
+bayati :: Fractional a => [a]
+bayati = [0, 1.5, 3, 5, 7, 8, 10]
+hijaz :: Fractional a => [a]
+hijaz = [0, 1, 4, 5, 7, 8.5, 10]
+sikah :: Fractional a => [a]
+sikah = [0, 1.5, 3.5, 5.5, 7, 8.5, 10.5]
+rast :: Fractional a => [a]
+rast = [0, 2, 3.5, 5, 7, 9, 10.5]
+iraq :: Fractional a => [a]
+iraq = [0, 1.5, 3.5, 5, 6.5, 8.5, 10.5]
+saba :: Fractional a => [a]
+saba = [0, 1.5, 3, 4, 6, 8, 10]
+
 -- 12 note scales
 chromatic :: Fractional a => [a]
 chromatic = [0,1,2,3,4,5,6,7,8,9,10,11]
@@ -251,5 +265,11 @@ scaleTable = [("minPent", minPent),
               ("messiaen5", messiaen5),
               ("messiaen6", messiaen6),
               ("messiaen7", messiaen7),
-              ("chromatic", chromatic)
+              ("chromatic", chromatic),
+              ("bayati", bayati),
+              ("hijaz", hijaz),
+              ("sikah", sikah),
+              ("rast", rast),
+              ("saba", saba),
+              ("iraq", iraq)
              ]

--- a/test/Sound/Tidal/ScalesTest.hs
+++ b/test/Sound/Tidal/ScalesTest.hs
@@ -19,249 +19,249 @@ run =
             it "can transform notes correctly over 2 octaves - minPent" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "minPent" twoOctavesOf5NoteScale)
-                    ("0 3 5 7 10 12 15 17 19 22"::Pattern Int)
+                    ("0 3 5 7 10 12 15 17 19 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - majPent" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "majPent" twoOctavesOf5NoteScale)
-                    ("0 2 4 7 9 12 14 16 19 21"::Pattern Int)
+                    ("0 2 4 7 9 12 14 16 19 21"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - ritusen" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "ritusen" twoOctavesOf5NoteScale)
-                    ("0 2 5 7 9 12 14 17 19 21"::Pattern Int)
+                    ("0 2 5 7 9 12 14 17 19 21"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - egyptian" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "egyptian" twoOctavesOf5NoteScale)
-                    ("0 2 5 7 10 12 14 17 19 22"::Pattern Int)
+                    ("0 2 5 7 10 12 14 17 19 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - kumai" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "kumai" twoOctavesOf5NoteScale)
-                    ("0 2 3 7 9 12 14 15 19 21"::Pattern Int)
+                    ("0 2 3 7 9 12 14 15 19 21"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - hirajoshi" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "hirajoshi" twoOctavesOf5NoteScale)
-                    ("0 2 3 7 8 12 14 15 19 20"::Pattern Int)
+                    ("0 2 3 7 8 12 14 15 19 20"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - iwato" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "iwato" twoOctavesOf5NoteScale)
-                    ("0 1 5 6 10 12 13 17 18 22"::Pattern Int)
+                    ("0 1 5 6 10 12 13 17 18 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - chinese" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "chinese" twoOctavesOf5NoteScale)
-                    ("0 4 6 7 11 12 16 18 19 23"::Pattern Int)
+                    ("0 4 6 7 11 12 16 18 19 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - indian" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "indian" twoOctavesOf5NoteScale)
-                    ("0 4 5 7 10 12 16 17 19 22"::Pattern Int)
+                    ("0 4 5 7 10 12 16 17 19 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - pelog" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "pelog" twoOctavesOf5NoteScale)
-                    ("0 1 3 7 8 12 13 15 19 20"::Pattern Int)
+                    ("0 1 3 7 8 12 13 15 19 20"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - prometheus" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "prometheus" twoOctavesOf5NoteScale)
-                    ("0 2 4 6 11 12 14 16 18 23"::Pattern Int)
+                    ("0 2 4 6 11 12 14 16 18 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - scriabin" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "scriabin" twoOctavesOf5NoteScale)
-                    ("0 1 4 7 9 12 13 16 19 21"::Pattern Int)
+                    ("0 1 4 7 9 12 13 16 19 21"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - gong" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "gong" twoOctavesOf5NoteScale)
-                    ("0 2 4 7 9 12 14 16 19 21"::Pattern Int)
+                    ("0 2 4 7 9 12 14 16 19 21"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - shang" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "shang" twoOctavesOf5NoteScale)
-                    ("0 2 5 7 10 12 14 17 19 22"::Pattern Int)
+                    ("0 2 5 7 10 12 14 17 19 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - jiao" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "jiao" twoOctavesOf5NoteScale)
-                    ("0 3 5 8 10 12 15 17 20 22"::Pattern Int)
+                    ("0 3 5 8 10 12 15 17 20 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - zhi" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "zhi" twoOctavesOf5NoteScale)
-                    ("0 2 5 7 9 12 14 17 19 21"::Pattern Int)
+                    ("0 2 5 7 9 12 14 17 19 21"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - yu" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "yu" twoOctavesOf5NoteScale)
-                    ("0 3 5 7 10 12 15 17 19 22"::Pattern Int)
+                    ("0 3 5 7 10 12 15 17 19 22"::Pattern Rational)
         describe "6 note scales" $ do
             let twoOctavesOf6NoteScale = "0 1 2 3 4 5 6 7 8 9 10 11"
             it "can transform notes correctly over 2 octaves - whole" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "whole" twoOctavesOf6NoteScale)
-                    ("0 2 4 6 8 10 12 14 16 18 20 22"::Pattern Int)
+                    ("0 2 4 6 8 10 12 14 16 18 20 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - wholetone" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "wholetone" twoOctavesOf6NoteScale)
-                    (Sound.Tidal.Scales.scale "whole" twoOctavesOf6NoteScale :: Pattern Int)
+                    (Sound.Tidal.Scales.scale "whole" twoOctavesOf6NoteScale :: Pattern Rational)
             it "can transform notes correctly over 2 octaves - augmented" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "augmented" twoOctavesOf6NoteScale)
-                    ("0 3 4 7 8 11 12 15 16 19 20 23"::Pattern Int)
+                    ("0 3 4 7 8 11 12 15 16 19 20 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - augmented2" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "augmented2" twoOctavesOf6NoteScale)
-                    ("0 1 4 5 8 9 12 13 16 17 20 21"::Pattern Int)
+                    ("0 1 4 5 8 9 12 13 16 17 20 21"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - hexMajor7" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "hexMajor7" twoOctavesOf6NoteScale)
-                    ("0 2 4 7 9 11 12 14 16 19 21 23"::Pattern Int)
+                    ("0 2 4 7 9 11 12 14 16 19 21 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - hexPhrygian" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "hexPhrygian" twoOctavesOf6NoteScale)
-                    ("0 1 3 5 8 10 12 13 15 17 20 22"::Pattern Int)
+                    ("0 1 3 5 8 10 12 13 15 17 20 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - hexDorian" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "hexDorian" twoOctavesOf6NoteScale)
-                    ("0 2 3 5 7 10 12 14 15 17 19 22"::Pattern Int)
+                    ("0 2 3 5 7 10 12 14 15 17 19 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - hexSus" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "hexSus" twoOctavesOf6NoteScale)
-                    ("0 2 5 7 9 10 12 14 17 19 21 22"::Pattern Int)
+                    ("0 2 5 7 9 10 12 14 17 19 21 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - hexMajor6" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "hexMajor6" twoOctavesOf6NoteScale)
-                    ("0 2 4 5 7 9 12 14 16 17 19 21"::Pattern Int)
+                    ("0 2 4 5 7 9 12 14 16 17 19 21"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - hexAeolian" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "hexAeolian" twoOctavesOf6NoteScale)
-                    ("0 3 5 7 8 10 12 15 17 19 20 22"::Pattern Int)
+                    ("0 3 5 7 8 10 12 15 17 19 20 22"::Pattern Rational)
         describe "7 note scales" $ do
             let twoOctavesOf7NoteScale = "0 1 2 3 4 5 6 7 8 9 10 11 12 13"
             it "can transform notes correctly over 2 octaves - major" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "major" twoOctavesOf7NoteScale)
-                    ("0 2 4 5 7 9 11 12 14 16 17 19 21 23"::Pattern Int)
+                    ("0 2 4 5 7 9 11 12 14 16 17 19 21 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - ionian" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "ionian" twoOctavesOf7NoteScale)
-                    (Sound.Tidal.Scales.scale "major" twoOctavesOf7NoteScale :: Pattern Int)
+                    (Sound.Tidal.Scales.scale "major" twoOctavesOf7NoteScale :: Pattern Rational)
             it "can transform notes correctly over 2 octaves - dorian" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "dorian" twoOctavesOf7NoteScale)
-                    ("0 2 3 5 7 9 10 12 14 15 17 19 21 22"::Pattern Int)
+                    ("0 2 3 5 7 9 10 12 14 15 17 19 21 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - aeolian" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "aeolian" twoOctavesOf7NoteScale)
-                    ("0 2 3 5 7 8 10 12 14 15 17 19 20 22"::Pattern Int)
+                    ("0 2 3 5 7 8 10 12 14 15 17 19 20 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - aeolian" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "minor" twoOctavesOf7NoteScale)
-                    (Sound.Tidal.Scales.scale "aeolian" twoOctavesOf7NoteScale::Pattern Int)
+                    (Sound.Tidal.Scales.scale "aeolian" twoOctavesOf7NoteScale::Pattern Rational)
             it "can transform notes correctly over 2 octaves - minor" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "minor" twoOctavesOf7NoteScale)
-                    (Sound.Tidal.Scales.scale "aeolian" twoOctavesOf7NoteScale::Pattern Int)
+                    (Sound.Tidal.Scales.scale "aeolian" twoOctavesOf7NoteScale::Pattern Rational)
             it "can transform notes correctly over 2 octaves - locrian" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "locrian" twoOctavesOf7NoteScale)
-                    ("0 1 3 5 6 8 10 12 13 15 17 18 20 22"::Pattern Int)
+                    ("0 1 3 5 6 8 10 12 13 15 17 18 20 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - harmonicMinor" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "harmonicMinor" twoOctavesOf7NoteScale)
-                    ("0 2 3 5 7 8 11 12 14 15 17 19 20 23"::Pattern Int)
+                    ("0 2 3 5 7 8 11 12 14 15 17 19 20 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - harmonicMajor" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "harmonicMajor" twoOctavesOf7NoteScale)
-                    ("0 2 4 5 7 8 11 12 14 16 17 19 20 23"::Pattern Int)
+                    ("0 2 4 5 7 8 11 12 14 16 17 19 20 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - melodicMinor" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "melodicMinor" twoOctavesOf7NoteScale)
-                    ("0 2 3 5 7 9 11 12 14 15 17 19 21 23"::Pattern Int)
+                    ("0 2 3 5 7 9 11 12 14 15 17 19 21 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - melodicMinorDesc" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "melodicMinorDesc" twoOctavesOf7NoteScale)
-                    (Sound.Tidal.Scales.scale "minor" twoOctavesOf7NoteScale::Pattern Int)
+                    (Sound.Tidal.Scales.scale "minor" twoOctavesOf7NoteScale::Pattern Rational)
             it "can transform notes correctly over 2 octaves - melodicMajor" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "melodicMajor" twoOctavesOf7NoteScale)
-                    ("0 2 4 5 7 8 10 12 14 16 17 19 20 22"::Pattern Int)
+                    ("0 2 4 5 7 8 10 12 14 16 17 19 20 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - bartok" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "bartok" twoOctavesOf7NoteScale)
-                    (Sound.Tidal.Scales.scale "melodicMajor" twoOctavesOf7NoteScale::Pattern Int)
+                    (Sound.Tidal.Scales.scale "melodicMajor" twoOctavesOf7NoteScale::Pattern Rational)
             it "can transform notes correctly over 2 octaves - hindu" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "hindu" twoOctavesOf7NoteScale)
-                    (Sound.Tidal.Scales.scale "melodicMajor" twoOctavesOf7NoteScale::Pattern Int)
+                    (Sound.Tidal.Scales.scale "melodicMajor" twoOctavesOf7NoteScale::Pattern Rational)
             it "can transform notes correctly over 2 octaves - todi" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "todi" twoOctavesOf7NoteScale)
-                    ("0 1 3 6 7 8 11 12 13 15 18 19 20 23"::Pattern Int)
+                    ("0 1 3 6 7 8 11 12 13 15 18 19 20 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - purvi" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "purvi" twoOctavesOf7NoteScale)
-                    ("0 1 4 6 7 8 11 12 13 16 18 19 20 23"::Pattern Int)
+                    ("0 1 4 6 7 8 11 12 13 16 18 19 20 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - marva" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "marva" twoOctavesOf7NoteScale)
-                    ("0 1 4 6 7 9 11 12 13 16 18 19 21 23"::Pattern Int)
+                    ("0 1 4 6 7 9 11 12 13 16 18 19 21 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - bhairav" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "bhairav" twoOctavesOf7NoteScale)
-                    ("0 1 4 5 7 8 11 12 13 16 17 19 20 23"::Pattern Int)
+                    ("0 1 4 5 7 8 11 12 13 16 17 19 20 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - ahirbhairav" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "ahirbhairav" twoOctavesOf7NoteScale)
-                    ("0 1 4 5 7 9 10 12 13 16 17 19 21 22"::Pattern Int)
+                    ("0 1 4 5 7 9 10 12 13 16 17 19 21 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - superLocrian" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "superLocrian" twoOctavesOf7NoteScale)
-                    ("0 1 3 4 6 8 10 12 13 15 16 18 20 22"::Pattern Int)
+                    ("0 1 3 4 6 8 10 12 13 15 16 18 20 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - romanianMinor" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "romanianMinor" twoOctavesOf7NoteScale)
-                    ("0 2 3 6 7 9 10 12 14 15 18 19 21 22"::Pattern Int)
+                    ("0 2 3 6 7 9 10 12 14 15 18 19 21 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - hungarianMinor" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "hungarianMinor" twoOctavesOf7NoteScale)
-                    ("0 2 3 6 7 8 11 12 14 15 18 19 20 23"::Pattern Int)
+                    ("0 2 3 6 7 8 11 12 14 15 18 19 20 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - neapolitanMinor" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "neapolitanMinor" twoOctavesOf7NoteScale)
-                    ("0 1 3 5 7 8 11 12 13 15 17 19 20 23"::Pattern Int)
+                    ("0 1 3 5 7 8 11 12 13 15 17 19 20 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - enigmatic" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "enigmatic" twoOctavesOf7NoteScale)
-                    ("0 1 4 6 8 10 11 12 13 16 18 20 22 23"::Pattern Int)
+                    ("0 1 4 6 8 10 11 12 13 16 18 20 22 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - spanish" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "spanish" twoOctavesOf7NoteScale)
-                    ("0 1 4 5 7 8 10 12 13 16 17 19 20 22"::Pattern Int)
+                    ("0 1 4 5 7 8 10 12 13 16 17 19 20 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - leadingWhole" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "leadingWhole" twoOctavesOf7NoteScale)
-                    ("0 2 4 6 8 10 11 12 14 16 18 20 22 23"::Pattern Int)
+                    ("0 2 4 6 8 10 11 12 14 16 18 20 22 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - lydianMinor" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "lydianMinor" twoOctavesOf7NoteScale)
-                    ("0 2 4 6 7 8 10 12 14 16 18 19 20 22"::Pattern Int)
+                    ("0 2 4 6 7 8 10 12 14 16 18 19 20 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - neapolitanMajor" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "neapolitanMajor" twoOctavesOf7NoteScale)
-                    ("0 1 3 5 7 9 11 12 13 15 17 19 21 23"::Pattern Int)
+                    ("0 1 3 5 7 9 11 12 13 15 17 19 21 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - locrianMajor" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "locrianMajor" twoOctavesOf7NoteScale)
-                    ("0 2 4 5 6 8 10 12 14 16 17 18 20 22"::Pattern Int)
+                    ("0 2 4 5 6 8 10 12 14 16 17 18 20 22"::Pattern Rational)
         describe "8 note scales" $ do
             let twoOctavesOf8NoteScale = "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15"
             it "can transform notes correctly over 2 octaves - diminished" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "diminished" twoOctavesOf8NoteScale)
-                    ("0 1 3 4 6 7 9 10 12 13 15 16 18 19 21 22"::Pattern Int)
+                    ("0 1 3 4 6 7 9 10 12 13 15 16 18 19 21 22"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - octatonic" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "octatonic" twoOctavesOf8NoteScale)
-                    (Sound.Tidal.Scales.scale "diminished" twoOctavesOf8NoteScale::Pattern Int)
+                    (Sound.Tidal.Scales.scale "diminished" twoOctavesOf8NoteScale::Pattern Rational)
             it "can transform notes correctly over 2 octaves - diminished2" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "diminished2" twoOctavesOf8NoteScale)
-                    ("0 2 3 5 6 8 9 11 12 14 15 17 18 20 21 23"::Pattern Int)
+                    ("0 2 3 5 6 8 9 11 12 14 15 17 18 20 21 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - octatonic2" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "octatonic2" twoOctavesOf8NoteScale)
-                    (Sound.Tidal.Scales.scale "diminished2" twoOctavesOf8NoteScale::Pattern Int)
+                    (Sound.Tidal.Scales.scale "diminished2" twoOctavesOf8NoteScale::Pattern Rational)
         describe "modes of limited transposition" $ do
             let twoOctavesOf6NoteScale = "0 1 2 3 4 5 6 7 8 9 10 11"
             let twoOctavesOf8NoteScale = "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15"
@@ -270,49 +270,51 @@ run =
             it "can transform notes correctly over 2 octaves - messiaen1" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "messiaen1" twoOctavesOf6NoteScale)
-                    (Sound.Tidal.Scales.scale "wholetone" twoOctavesOf6NoteScale::Pattern Int)
+                    (Sound.Tidal.Scales.scale "wholetone" twoOctavesOf6NoteScale::Pattern Rational)
             it "can transform notes correctly over 2 octaves - messiaen2" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "messiaen2" twoOctavesOf8NoteScale)
-                    (Sound.Tidal.Scales.scale "diminished" twoOctavesOf8NoteScale::Pattern Int)
+                    (Sound.Tidal.Scales.scale "diminished" twoOctavesOf8NoteScale::Pattern Rational)
             it "can transform notes correctly over 2 octaves - messiaen3" $ do
                 -- tone, semitone, semitone, tone, semitone, semitone, tone, semitone, semitone
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "messiaen3" twoOctavesOf9NoteScale)
-                    ("0 2 3 4 6 7 8 10 11 12 14 15 16 18 19 20 22 23"::Pattern Int)
+                    ("0 2 3 4 6 7 8 10 11 12 14 15 16 18 19 20 22 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - messiaen4" $ do
                 -- semitone, semitone, minor third, semitone, semitone, semitone, minor third, semitone
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "messiaen4" twoOctavesOf8NoteScale)
-                    ("0 1 2 5 6 7 8 11 12 13 14 17 18 19 20 23"::Pattern Int)
+                    ("0 1 2 5 6 7 8 11 12 13 14 17 18 19 20 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - messiaen5" $ do
                 -- semitone, major third, semitone, semitone, major third, semitone
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "messiaen5" twoOctavesOf6NoteScale)
-                    ("0 1 5 6 7 11 12 13 17 18 19 23"::Pattern Int)
+                    ("0 1 5 6 7 11 12 13 17 18 19 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - messiaen6" $ do
                 -- tone, tone, semitone, semitone, tone, tone, semitone, semitone
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "messiaen6" twoOctavesOf8NoteScale)
-                    ("0 2 4 5 6 8 10 11 12 14 16 17 18 20 22 23"::Pattern Int)
+                    ("0 2 4 5 6 8 10 11 12 14 16 17 18 20 22 23"::Pattern Rational)
             it "can transform notes correctly over 2 octaves - messiaen7" $ do
                 -- semitone, semitone, semitone, tone, semitone, semitone, semitone, semitone, tone, semitone
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "messiaen7" twoOctavesOf10NoteScale)
-                    ("0 1 2 3 5 6 7 8 9 11 12 13 14 15 17 18 19 20 21 23"::Pattern Int)
+                    ("0 1 2 3 5 6 7 8 9 11 12 13 14 15 17 18 19 20 21 23"::Pattern Rational)
+-- {-                    
         describe "12 note scales" $ do
             let twoOctavesOf12NoteScale = "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23"
             it "can transform notes correctly over 2 octaves - chromatic" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "chromatic" twoOctavesOf12NoteScale)
-                    (twoOctavesOf12NoteScale::Pattern Int)
+                    ("0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23"::Pattern Rational)
+-- -}
         describe "edge cases" $ do
             it "responds to unknown scales by mapping to octaves" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "ergaerv" "0 1 2 3 4")
-                    ("0 12 24 36 48"::Pattern Int)
+                    ("0 12 24 36 48"::Pattern Rational)
             it "correctly maps negative numbers" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "major" "0 -1 -2 -3 -4 -5 -6 -7 -8 -9 -10 -11 -12 -13")
-                    ("0 -1 -3 -5 -7 -8 -10 -12 -13 -15 -17 -19 -20 -22 "::Pattern Int)
+                    ("0 -1 -3 -5 -7 -8 -10 -12 -13 -15 -17 -19 -20 -22 "::Pattern Rational)
            

--- a/test/Sound/Tidal/ScalesTest.hs
+++ b/test/Sound/Tidal/ScalesTest.hs
@@ -300,14 +300,12 @@ run =
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "messiaen7" twoOctavesOf10NoteScale)
                     ("0 1 2 3 5 6 7 8 9 11 12 13 14 15 17 18 19 20 21 23"::Pattern Rational)
--- {-                    
         describe "12 note scales" $ do
             let twoOctavesOf12NoteScale = "0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23"
             it "can transform notes correctly over 2 octaves - chromatic" $ do
                 compareP (Arc 0 1)
                     (Sound.Tidal.Scales.scale "chromatic" twoOctavesOf12NoteScale)
                     ("0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23"::Pattern Rational)
--- -}
         describe "edge cases" $ do
             it "responds to unknown scales by mapping to octaves" $ do
                 compareP (Arc 0 1)


### PR DESCRIPTION
I made scales Fractional instead of Num so I could add 24 note scales (or quartertones), fixing #579

The scale has to be used with `note` or `n` to work with fractions

`d1 $ note (scale "bayati" "0 .. 8") # sound "superfork"`

I added 6 new scales.

There's probably a more elegant way to refactor this, to parametrize the number of notes in a scale (mainly 12 or 24) like how it's done in supercollider:
https://github.com/supercollider/supercollider/blob/f65a1ef7bfb100f4ccb7dcab3a6dff6826be4344/SCClassLibrary/Common/Collections/Scale.sc

