### PR TITLE
export drawLineSz

### DIFF
--- a/src/Sound/Tidal/Show.hs
+++ b/src/Sound/Tidal/Show.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TypeSynonymInstances, FlexibleInstances, RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Sound.Tidal.Show (show, showAll, draw, drawLine) where
+module Sound.Tidal.Show (show, showAll, draw, drawLine, drawLineSz) where
 
 import Sound.Tidal.Pattern
 


### PR DESCRIPTION
Personally I think making `drawLineSz` usable, rather than just keeping it internal, would be nice? It allows one to do cool things such as screen-flooding live, and to visualize very long/complex patterns. I don't really see why not? 