### PR TITLE
Simplify tidal-boot-script-path in tidal.el

### DIFF
--- a/tidal.el
+++ b/tidal.el
@@ -66,7 +66,7 @@
              ("separator" . "\\")
              ))
           ((or (string-equal system-type "darwin") (string-equal system-type "gnu/linux"))
-           '(("path" . "ghc-pkg field -f ~/.cabal/store/ghc-$(ghc --numeric-version)/package.db tidal data-dir")
+           '(("path" . "ghc-pkg field tidal data-dir")
              ("separator" . "/")
              ))
           )


### PR DESCRIPTION
Newer layouts of ~/.cabal appear to structure things differently,
and as suggested in tidalcycles/Tidal#615 this works for the
Unix case.