### PR TITLE
add qualified imports

### DIFF
--- a/BootTidal.hs
+++ b/BootTidal.hs
@@ -5,6 +5,9 @@ import Sound.Tidal.Context
 
 import System.IO (hSetEncoding, stdout, utf8)
 
+import qualified Control.Concurrent.MVar as MV
+import qualified Sound.Tidal.Tempo as Tempo
+
 hSetEncoding stdout utf8
 
 -- total latency = oLatency + cFrameTimespan
@@ -29,7 +32,7 @@ let only = (hush >>)
     all = streamAll tidal
     resetCycles = streamResetCycles tidal
     setcps = asap . cps
-    getcps = do tempo <- readMVar $ sTempoMV tidal
+    getcps = do tempo <- MV.readMVar $ sTempoMV tidal
                 return $ Tempo.cps tempo
     xfade i = transition tidal True (Sound.Tidal.Transition.xfadeIn 4) i
     xfadeIn i t = transition tidal True (Sound.Tidal.Transition.xfadeIn t) i

--- a/BootTidal.hs
+++ b/BootTidal.hs
@@ -7,6 +7,7 @@ import System.IO (hSetEncoding, stdout, utf8)
 
 import qualified Control.Concurrent.MVar as MV
 import qualified Sound.Tidal.Tempo as Tempo
+import qualified Sound.OSC.FD as O
 
 hSetEncoding stdout utf8
 
@@ -34,6 +35,9 @@ let only = (hush >>)
     setcps = asap . cps
     getcps = do tempo <- MV.readMVar $ sTempoMV tidal
                 return $ Tempo.cps tempo
+    getnow = do tempo <- MV.readMVar $ sTempoMV tidal
+                now <- O.time
+                return $ fromRational $ Tempo.timeToCycles tempo now
     xfade i = transition tidal True (Sound.Tidal.Transition.xfadeIn 4) i
     xfadeIn i t = transition tidal True (Sound.Tidal.Transition.xfadeIn t) i
     histpan i t = transition tidal True (Sound.Tidal.Transition.histpan t) i


### PR DESCRIPTION
BootTidal.hs needs to make sure some modules are imported for `getcps` to work properly, and I also took the opportunity to provide a `getnow` command that works similar to a function that existed before the reworking of Stream.hs