### PR TITLE
Set travis badge on the right branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-Tidal [![Build Status](https://travis-ci.org/tidalcycles/Tidal.svg?branch=main)](https://travis-ci.org/tidalcycles/Tidal.svg?branch=main)
+Tidal [![Build Status](https://travis-ci.org/tidalcycles/Tidal.svg?branch=main)](https://travis-ci.org/tidalcycles/Tidal)
 =====
 
 Language for live coding of pattern

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
 
-Tidal [![Build Status](https://travis-ci.org/tidalcycles/Tidal.svg)](https://travis-ci.org/tidalcycles/Tidal)
+Tidal [![Build Status](https://travis-ci.org/tidalcycles/Tidal.svg?branch=main)](https://travis-ci.org/tidalcycles/Tidal.svg?branch=main)
 =====
 
 Language for live coding of pattern
 
-For documentation, mailing list and more info see here:
+For documentation, mailing list and more info see here:  
   https://tidalcycles.org/
 
-You can help speed up Tidal development by sending coffee here:
+You can help speed up Tidal development by sending coffee here:  
   https://ko-fi.com/yaxulive#
 
 (c) Alex McLean and contributors, 2019
 
-Distributed under the terms of the GNU Public license version 3 (or
-later).
+Distributed under the terms of the GNU Public license version 3 (or later).
 


### PR DESCRIPTION
It was by default on `master`, that does not exists anymore due to #683 