### PR TITLE
Reimplementing grain custom parameter

### DIFF
--- a/src/Sound/Tidal/Params.hs
+++ b/src/Sound/Tidal/Params.hs
@@ -207,6 +207,9 @@ gain = pF "gain"
 gate :: Pattern Double -> ControlPattern
 gate = pF "gate"
 
+grain' :: Pattern String -> ControlPattern
+grain' = grp [mF "begin", mF "end"]
+
 hatgrain :: Pattern Double -> ControlPattern
 hatgrain = pF "hatgrain"
 -- | a pattern of numbers from 0 to 1. Applies the cutoff frequency of the high-pass filter.

--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -1955,3 +1955,9 @@ binary = binaryN 8
 
 ascii :: Pattern String -> Pattern Bool
 ascii p = squeezeJoin $ (listToPat . concatMap (__binary 8 . ord)) <$> p
+
+grain :: Pattern Double -> Pattern Double -> ControlPattern
+grain s w = P.begin b # P.end e
+  where b = s
+        e = s + w
+        


### PR DESCRIPTION
Remaps begin and end to begin and width, to create a granulising effect that can be patterned
eg.

d1 $ s "bev" >| grain ((1/16) * "0 3 4 6*<1 2 3>") (1/64)

or for a simpler grain selection with

d1 $ grain' "0.0125:0.06125" # s "bev"