### PR TITLE
Handle Note type in tidal-parse

### DIFF
--- a/src/Sound/Tidal/Pattern.hs
+++ b/src/Sound/Tidal/Pattern.hs
@@ -44,7 +44,7 @@ import           Sound.Tidal.Utils (matchMaybe)
 type Time = Rational
 
 -- | Note is Double, but with a different parsing
-newtype Note = Note { unNote :: Double } deriving (Typeable, Data, Generic, Eq, Ord, Show, Enum, Num, Fractional)
+newtype Note = Note { unNote :: Double } deriving (Typeable, Data, Generic, Eq, Ord, Show, Enum, Num, Fractional, Floating, Real)
 instance NFData Note
 
 -- | The 'sam' (start of cycle) for the given time value

--- a/tidal-parse/src/Sound/Tidal/Parse.hs
+++ b/tidal-parse/src/Sound/Tidal/Parse.hs
@@ -710,7 +710,7 @@ instance Parse (Int -> Pattern Double -> Pattern a -> Pattern a) where
   parser = $(fromTidal "degradeOverBy")
 
 instance Parse (Int -> Pattern T.Note -> Pattern a -> Pattern a) where
-  parser = parser
+  parser = empty
 
 instance Parse ((a -> b -> Pattern c) -> [a] -> b -> Pattern c) where
   parser =
@@ -751,7 +751,7 @@ instance Parse (Pattern Double -> (Pattern a -> Pattern a) -> Pattern a -> Patte
     $(fromTidal "plyWith")
 
 instance Parse (Pattern T.Note -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a) where
-  parser = parser
+  parser = empty
 
 instance Parse ([Int] -> (Pattern a -> Pattern a) -> Pattern a -> Pattern a) where
   parser = $(fromTidal "foldEvery")

--- a/tidal-parse/test/Sound/Tidal/TidalParseTest.hs
+++ b/tidal-parse/test/Sound/Tidal/TidalParseTest.hs
@@ -13,7 +13,7 @@ stripContext = setContext $ Context []
 
 parsesTo :: String -> ControlPattern -> Property
 parsesTo str p = x `shouldBe` y
-  where x = (\p' st -> query (stripContext p') st) <$> parseTidal str <*> Right (State (Arc 0 16) Map.empty)
+  where x = query . stripContext <$> parseTidal str <*> Right (State (Arc 0 16) Map.empty)
         y = Right $ query (stripContext p) $ State (Arc 0 16) Map.empty
 
 causesParseError :: String -> Property


### PR DESCRIPTION
Should fix #725 

Test are still broken but with an error like
`*** Failed! Exception: '<<loop>>' (after 1 test): | Exception thrown while showing test case: '<<loop>>' |`

Think it's something not bind to the `Note` newtype. 
@dktr0 can you help me about that?