### PR TITLE
Add VN to toDatum patterns

### DIFF
--- a/src/Sound/Tidal/Stream.hs
+++ b/src/Sound/Tidal/Stream.hs
@@ -42,7 +42,6 @@ import           Sound.Tidal.Config
 import           Sound.Tidal.Core (stack, silence)
 import           Sound.Tidal.Pattern
 import qualified Sound.Tidal.Tempo as T
--- import qualified Sound.OSC.Datum as O
 import           Data.List (sortOn)
 import           System.Random (getStdRandom, randomR)
 import           Sound.Tidal.Show ()
@@ -208,6 +207,7 @@ startMulti _ _ = putStrLn $ "startMulti has been removed, please check the lates
 
 toDatum :: Value -> O.Datum
 toDatum (VF x Nothing) = O.float x
+toDatum (VN x Nothing) = O.float x
 toDatum (VI x Nothing) = O.int32 x
 toDatum (VS x Nothing) = O.string x
 toDatum (VR x Nothing) = O.float $ ((fromRational x) :: Double)
@@ -569,7 +569,3 @@ ctrlListen sMapMV c
                      return ()
         catchAny :: IO a -> (E.SomeException -> IO a) -> IO a
         catchAny = E.catch
-
-
-
-

--- a/test/Sound/Tidal/StreamTest.hs
+++ b/test/Sound/Tidal/StreamTest.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Sound.Tidal.StreamTest where
+
+import Test.Microspec
+import TestUtils
+import Sound.Tidal.Stream
+import Sound.Tidal.Pattern
+import qualified Sound.OSC.FD as O
+
+run :: Microspec ()
+run =
+  describe "Sound.Tidal.Stream" $ do
+    describe "toDatum" $ do
+      it "should convert VN to osc float" $ do
+        toDatum (VN (Note 3.5) Nothing) `shouldBe` O.float 3.5
+          

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -8,6 +8,7 @@ import Sound.Tidal.ParseTest
 import Sound.Tidal.PatternTest
 import Sound.Tidal.ControlTest
 import Sound.Tidal.ScalesTest
+import Sound.Tidal.StreamTest
 import Sound.Tidal.UITest
 import Sound.Tidal.UtilsTest
 import Sound.Tidal.ExceptionsTest
@@ -20,6 +21,7 @@ main = microspec $ do
   Sound.Tidal.PatternTest.run
   Sound.Tidal.ControlTest.run
   Sound.Tidal.ScalesTest.run
+  Sound.Tidal.StreamTest.run
   Sound.Tidal.UITest.run
   Sound.Tidal.UtilsTest.run
   Sound.Tidal.ExceptionsTest.run

--- a/tidal.cabal
+++ b/tidal.cabal
@@ -82,6 +82,7 @@ test-suite tests
                  Sound.Tidal.ParseTest
                  Sound.Tidal.PatternTest
                  Sound.Tidal.ScalesTest
+                 Sound.Tidal.StreamTest
                  Sound.Tidal.UITest
                  Sound.Tidal.UtilsTest
                  Sound.Tidal.ExceptionsTest
@@ -89,6 +90,7 @@ test-suite tests
   build-depends:
                 base ==4.*
               , microspec >= 0.2.0.1
+              , hosc >= 0.17 && < 0.19
               , containers
               , parsec
               , tidal


### PR DESCRIPTION
Add VN pattern to datum, as discussed in #745 
Add a simple test, not so meaningful but needed to replicate the bug and write the missing code