### PR TITLE
Fix parsing of pattern groupping shorthand

### DIFF
--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -339,7 +339,7 @@ pSequence f = do
     a <- pPart f
     spaces
     do
-      symbol ".."
+      try $ symbol ".."
       b <- pPart f
       return $ TPat_EnumFromTo a b
       <|> pElongate a

--- a/test/Sound/Tidal/ParseTest.hs
+++ b/test/Sound/Tidal/ParseTest.hs
@@ -23,6 +23,14 @@ run =
         compareP (Arc 0 2)
           ("0 1 2 3 4 5 6 7 8 0 10 20 30 40 50" :: Pattern Int)
           (fastCat $ map (pure . read) $ words "0 1 2 3 4 5 6 7 8 0 10 20 30 40 50")
+      it "can parse pattern groups" $ do
+        compareP (Arc 0 1)
+          ("[bd sd] hh" :: Pattern String)
+          (fastCat ["bd sd", "hh"])
+      it "can parse pattern groups shorthand " $ do
+        compareP (Arc 0 1)
+          ("bd sd . hh hh hh" :: Pattern String)
+          ("[bd sd] [hh hh hh]")
       it "can alternate with <>" $ do
         compareP (Arc 0 2)
           ("a <b c>" :: Pattern String)


### PR DESCRIPTION
Regression was introduced in 262e082cd5c33c824452d93fdcf972d4ce12ca56 during code reformating as a part of PR #776.

This caused basic patterns like `a . b` fail rather confusingly:

    Error in pattern: Syntax error in sequence:
      "a . b"
         ^
    unexpected " "
    expecting ".."

This commit brings back the forgotten `try` for `symbol ".."` and adds parsing tests for a pattern group and its shorthand form.

---

We should extend the parser test suite with the rest of the examples from https://tidalcycles.org/Mini_notation_syntax to avoid such regressions. Being new to Tidal's microsyntax it took me a lot of squinting to establish that the parser is indeed broken and it's not something with my editor/terminal setup that causes basic examples to fail. 