### PR TITLE
Fix issue with OSC path substitution

### DIFF
--- a/src/Sound/Tidal/Stream.hs
+++ b/src/Sound/Tidal/Stream.hs
@@ -287,8 +287,9 @@ substitutePath str cm = parse str
           where (a,b) = break (== '}') xs
 
 getString :: ValueMap -> String -> Maybe String
-getString cm s = defaultValue $ simpleShow <$> Map.lookup s cm
-                      where simpleShow :: Value -> String
+getString cm s = (simpleShow <$> Map.lookup param cm) <|> defaultValue dflt
+                      where (param, dflt) = break (== '=') s
+                            simpleShow :: Value -> String
                             simpleShow (VS str) = str
                             simpleShow (VI i) = show i
                             simpleShow (VF f) = show f
@@ -299,11 +300,9 @@ getString cm s = defaultValue $ simpleShow <$> Map.lookup s cm
                             simpleShow (VState _) = show "<stateful>"
                             simpleShow (VPattern _) = show "<pattern>"
                             simpleShow (VList _) = show "<list>"
-                            (_, dflt) = break (== '=') s
-                            defaultValue :: Maybe String -> Maybe String
-                            defaultValue Nothing | null dflt = Nothing
-                                                 | otherwise = Just $ tail dflt
-                            defaultValue x = x
+                            defaultValue :: String -> Maybe String
+                            defaultValue ('=':dfltVal) = Just dfltVal
+                            defaultValue _ = Nothing
 
 playStack :: PlayMap -> ControlPattern
 playStack pMap = stack $ map pattern active

--- a/test/Sound/Tidal/StreamTest.hs
+++ b/test/Sound/Tidal/StreamTest.hs
@@ -6,6 +6,7 @@ import Test.Microspec
 import Sound.Tidal.Stream
 import Sound.Tidal.Pattern
 import qualified Sound.OSC.FD as O
+import qualified Data.Map.Strict as M
 
 run :: Microspec ()
 run =
@@ -13,4 +14,23 @@ run =
     describe "toDatum" $ do
       it "should convert VN to osc float" $ do
         toDatum (VN (Note 3.5)) `shouldBe` O.float (3.5 :: Double)
-          
+    
+    describe "substitutePath" $ do
+      -- ValueMap
+      let state = M.fromList [("sound", VS "sn"), ("n", VI 8)]
+      it "should return same string if no params are specified" $ do
+        substitutePath "/s_new" state `shouldBe` Just "/s_new"
+      it "should substitute values for params if present" $ do
+        substitutePath "/{sound}/{n}/vol" state `shouldBe` Just "/sn/8/vol"
+      it "should return Nothing if a param is not present" $ do
+        substitutePath "/{sound}/{inst}" state `shouldBe` Nothing
+    
+    describe "getString" $ do
+      it "should return Nothing for missing params" $ do
+        getString M.empty "s" `shouldBe` Nothing
+      it "should work for strings" $ do
+        getString (M.singleton "s" (VS "sn")) "s" `shouldBe` Just "sn"
+      it "should work for params with fallback expressions" $ do
+        getString (M.singleton "s" (VS "sn")) "s=bd" `shouldBe` Just "sn"
+      it "should work for missing params with fallback expressions" $ do
+        getString M.empty "s=bd" `shouldBe` Just "bd"


### PR DESCRIPTION
I was adding some tests and discovered a bug with custom OSC paths: If you specify a path with a fallback (like `"/play/{s=bd}"`), Tidal always subs in the fallback, even if the param name exists in a given event.