### PR TITLE
Ctrl UI Changes

### DIFF
--- a/BootTidal.hs
+++ b/BootTidal.hs
@@ -66,7 +66,7 @@ let only = (hush >>)
 :}
 
 :{
-let get = streamGet tidal
+let getState = streamGet tidal
     setI = streamSetI tidal
     setF = streamSetF tidal
     setS = streamSetS tidal

--- a/BootTidal.hs
+++ b/BootTidal.hs
@@ -66,7 +66,8 @@ let only = (hush >>)
 :}
 
 :{
-let setI = streamSetI tidal
+let get = streamGet tidal
+    setI = streamSetI tidal
     setF = streamSetF tidal
     setS = streamSetS tidal
     setR = streamSetR tidal


### PR DESCRIPTION
(Whittling away at my other PR while I figure out how to proceed with it.)

It seems to me that it would be good to specifically pattern match on the `"/ctrl"` OSC path, especially if Tidal moves toward a fuller OSC api. This is technically a breaking change, but seems like it would be low-impact, because all the documentation I've seen has consistently referred to that message as `/ctrl`. Let me know if that's not the case.

I also added a handy function for getting a current state variable, which was nice for testing. I also made a BootTidal alias. `get` seemed to match `setI` etc, but maybe it's too generic? Let me know what you think—thanks!