### PR TITLE
Add more playback controls to OSC API

### DIFF
--- a/BootTidal.hs
+++ b/BootTidal.hs
@@ -19,6 +19,7 @@ let only = (hush >>)
     mute = streamMute tidal
     unmute = streamUnmute tidal
     unmuteAll = streamUnmuteAll tidal
+    unsoloAll = streamUnsoloAll tidal
     solo = streamSolo tidal
     unsolo = streamUnsolo tidal
     once = streamOnce tidal


### PR DESCRIPTION
This PR adds a missing unsoloAll to the set of stream playback controls. It also adds support for the rest of the similar playback controls (solo/unsolo/unsoloAll/hush) in the OSC control API.