### PR TITLE
.cabal: tweak description

### DIFF
--- a/tidal.cabal
+++ b/tidal.cabal
@@ -1,7 +1,7 @@
 name:                tidal
 version:             1.7.3
 synopsis:            Pattern language for improvised music
--- description:
+description:         Tidal is a domain specific language for live coding patterns.
 homepage:            http://tidalcycles.org/
 license:             GPL-3
 license-file:        LICENSE
@@ -16,8 +16,6 @@ tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC
 data-files:          BootTidal.hs
 
 Extra-source-files: README.md CHANGELOG.md tidal.el
-
-Description: Tidal is a domain specific language for live coding pattern.
 
 library
   ghc-options: -Wall


### PR DESCRIPTION
tiny changes to the description field in tidal.cabal:

- make "live coding pattern" plural
- move it up to usual place in .cabal file