### PR TITLE
Handle negative ratio shorthands also for rationals

### DIFF
--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -565,22 +565,25 @@ pE thing = do (n,k,s) <- parens pair
                    return (a, b, c)
 
 pRatio :: MyParser Rational
-pRatio = do s <- sign
-            n <- read <$> many1 digit
-            result <- do char '%'
-                         d <- decimal
-                         return (n%d)
-                      <|>
-                      do char '.'
-                         frac <- many1 digit
-                         -- A hack, but not sure if doing this
-                         -- numerically would be any faster..
-                         return (toRational ((read $ show n ++ "." ++ frac)  :: Double))
-                      <|>
-                      return (n%1)
-            c <- pRatioChar <|> return 1
-            return $ applySign s (result * c)
-         <|> pRatioChar
+pRatio = do 
+  s <- sign
+  r <- do n <- read <$> many1 digit
+          result <- do char '%'
+                       d <- decimal
+                       return (n%d)
+                    <|>
+                    do char '.'
+                       frac <- many1 digit
+                       -- A hack, but not sure if doing this
+                       -- numerically would be any faster..
+                       return (toRational ((read $ show n ++ "." ++ frac) :: Double))
+                    <|>
+                    return (n%1)
+          c <- pRatioChar <|> return 1
+          return (result * c)
+        <|> 
+        pRatioChar
+  return $ applySign s r
 
 pRatioChar :: Fractional a => MyParser a
 pRatioChar = do char 'w'

--- a/test/Sound/Tidal/UITest.hs
+++ b/test/Sound/Tidal/UITest.hs
@@ -330,11 +330,17 @@ run =
           ("t f f f f f f f" :: Pattern Bool)
 
     describe "binaryN" $ do
-      it "convert a number to a pattern of boolean of specified length" $ do
+      it "converts a number to a pattern of boolean of specified length" $ do
         compareP (Arc 0 1)
           (binaryN 4 "8")
           ("t f f f" :: Pattern Bool)
-      it "convert a number to a pattern of boolean of specified patternable length" $ do
+      it "converts a number to a pattern of boolean of specified patternable length" $ do
         compareP (Arc 0 2)
           (binaryN "<4 8>" "8")
           (cat ["t f f f", "f f f f t f f f"] :: Pattern Bool)
+
+    describe "off" $ do
+      it "superimposes and shifts pattern" $ do
+        compareP (Arc 0 1)
+          (off "-e" id $ s "0")
+          (superimpose ("e" <~) $ s "0")


### PR DESCRIPTION
I noticed that something like
```
d1 $ off "-e" $ s "bd"
```
was still not working.