### PR TITLE
fixing broken example for contrast

### DIFF
--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -1739,7 +1739,7 @@ _pickF i fs p =  (fs !!! i) p
 -- | @contrast p f f' p'@ splits controlpattern @p'@ in two, applying
 -- the function @f@ to one and @f'@ to the other. This depends on
 -- whether events in it contains values matching with those in @p@.
--- For example in @contrast (n "1") (# crush 3) (# vowel "a") $ n "0 1" # s "bd sn" # speed 3@,
+-- For example in @contrast (# crush 3) (# vowel "a") (n "1") $ n "0 1" # s "bd sn" # speed 3@,
 -- the first event will have the vowel effect applied and the second
 -- will have the crush applied.
 contrast :: (ControlPattern -> ControlPattern) -> (ControlPattern -> ControlPattern)


### PR DESCRIPTION
The example in the code for the `contrast` function was broken because the arguments weren't in the correct order. This seems to fix it.