### PR TITLE
Add listener build workflows

### DIFF
--- a/.github/workflows/listener-build-linux.yml
+++ b/.github/workflows/listener-build-linux.yml
@@ -1,0 +1,126 @@
+name: build-listener-linux
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc: ['9.0.1']
+        cabal: ['3.4.0.0']
+        
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Setup Haskell
+      uses: haskell/actions/setup@v1
+      id: setup-haskell-cabal
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+        
+    - name: Freeze
+      run: |
+        cabal freeze
+
+    - name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cabal/packages
+          ~/.cabal/store
+          dist-newstyle
+        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('tidal-listener/src') }}
+
+    - name: cabal update and build
+      run: |
+        cabal update
+        cabal build --enable-tests tidal-listener
+
+    - name: move GHC libs and configs
+      run: |
+        mkdir -p tidal-listener/binary/haskell-libs/ghc-packages/
+        cp -r ${{ steps.setup-haskell-cabal.outputs.ghc-path }}/../lib/ghc-${{ matrix.ghc }}/* tidal-listener/binary/haskell-libs/ghc-packages
+            
+    - name: move installed packages
+      run: | 
+        mkdir -p tidal-listener/binary/haskell-libs/packages/
+        cp -r ${{ steps.setup-haskell-cabal.outputs.cabal-store }}/ghc-${{ matrix.ghc }}/* tidal-listener/binary/haskell-libs/packages
+        ls tidal-listener/binary/haskell-libs/packages
+   
+    - name: change paths in config files (GHC)
+      run: |
+        mv tidal-listener/binary/haskell-libs/ghc-packages/package.conf.d tidal-listener/binary/haskell-libs/package.conf.d
+        sed -i 's/\/opt\/ghc\/${{ matrix.ghc }}\/lib\/ghc-${{ matrix.ghc }}/${pkgroot}\/ghc-packages/g' tidal-listener/binary/haskell-libs/package.conf.d/*
+     
+    - name: change paths in config files (cabal)
+      run: |
+        mv tidal-listener/binary/haskell-libs/packages/package.db tidal-listener/binary/haskell-libs/package.db
+        sed -i 's/\/home\/runner\/.cabal\/store\/ghc-${{ matrix.ghc }}/${pkgroot}\/packages/g' tidal-listener/binary/haskell-libs/package.db/*
+   
+    - name: move ghc settings etc
+      run: |
+        mv tidal-listener/binary/haskell-libs/ghc-packages/settings tidal-listener/binary/haskell-libs/settings
+        mv tidal-listener/binary/haskell-libs/ghc-packages/platformConstants tidal-listener/binary/haskell-libs/platformConstants
+        mv tidal-listener/binary/haskell-libs/ghc-packages/llvm-targets tidal-listener/binary/haskell-libs/llvm-targets
+        mv tidal-listener/binary/haskell-libs/ghc-packages/llvm-passes tidal-listener/binary/haskell-libs/llvm-passes
+
+    - name: ghc-pkg recache
+      run: |
+        ghc-pkg --package-db=tidal-listener/binary/haskell-libs/package.conf.d recache
+        ghc-pkg --package-db=tidal-listener/binary/haskell-libs/package.db recache
+        ghc-pkg --package-db=tidal-listener/binary/haskell-libs/package.conf.d --package-db=tidal-listener/binary/haskell-libs/package.db check
+
+    - name: move c-libs
+      run: |
+        mkdir -p tidal-listener/binary/c-libs/
+        cp /usr/lib/x86_64-linux-gnu/libz.so.1             tidal-listener/binary/c-libs/libz.so.1
+        cp /usr/lib/x86_64-linux-gnu/libtinfo.so.6         tidal-listener/binary/c-libs/libtinfo.so.6
+        cp /usr/lib/x86_64-linux-gnu/librt.so.1            tidal-listener/binary/c-libs/librt.so.1
+        cp /usr/lib/x86_64-linux-gnu/libutil.so.1          tidal-listener/binary/c-libs/libutil.so.1
+        cp /usr/lib/x86_64-linux-gnu/libpthread.so.0       tidal-listener/binary/c-libs/libpthread.so.0
+        cp /usr/lib/x86_64-linux-gnu/libm.so.6             tidal-listener/binary/c-libs/libm.so.6
+        cp /usr/lib/x86_64-linux-gnu/libgmp.so.10          tidal-listener/binary/c-libs/libgmp.so.10
+        cp /usr/lib/x86_64-linux-gnu/libc.so.6             tidal-listener/binary/c-libs/libc.so.6
+        cp /usr/lib/x86_64-linux-gnu/libdl.so.2            tidal-listener/binary/c-libs/libdl.so.2
+        ln -s /usr/lib/x86_64-linux-gnu/libz.so.1          tidal-listener/binary/c-libs/libz.so
+        ln -s /usr/lib/x86_64-linux-gnu/libtinfo.so.6      tidal-listener/binary/c-libs/libtinfo.so
+        ln -s /usr/lib/x86_64-linux-gnu/librt.so.1         tidal-listener/binary/c-libs/librt.so
+        ln -s /usr/lib/x86_64-linux-gnu/libutil.so.1       tidal-listener/binary/c-libs/libutil.so
+        ln -s /usr/lib/x86_64-linux-gnu/libpthread.so.0    tidal-listener/binary/c-libs/libpthread.so
+        ln -s /usr/lib/x86_64-linux-gnu/libm.so.6          tidal-listener/binary/c-libs/libm.so
+        ln -s /usr/lib/x86_64-linux-gnu/libgmp.so.10       tidal-listener/binary/c-libs/libgmp.so
+        ln -s /usr/lib/x86_64-linux-gnu/libc.so.6          tidal-listener/binary/c-libs/libc.so
+        ln -s /usr/lib/x86_64-linux-gnu/libdl.so.2         tidal-listener/binary/c-libs/libdl.so
+
+    - name: remove unneccessary libs 
+      run: |
+        cd tidal-listener/binary/haskell-libs/ghc-packages
+        rm -r ghc-${{ matrix.ghc }}
+        rm -r Cabal-*
+            
+    - name: fake gcc
+      run: |
+        mkdir -p tidal-listener/binary/haskell-libs/bin/
+        cp -r tidal-listener/fake_gcc.sh tidal-listener/binary/haskell-libs/bin/fake_gcc.sh
+        sed -i 's/cc/bin\/fake_gcc.sh/g' tidal-listener/binary/haskell-libs/settings
+        chmod 755 tidal-listener/binary/haskell-libs/bin/fake_gcc.sh
+   
+    - name: move executable
+      run: cp -r dist-newstyle/build/x86_64-linux/ghc-${{ matrix.ghc }}/tidal-listener-0.1.0.0/x/tidal-listener/build/tidal-listener/tidal-listener tidal-listener/binary/tidal-listener
+  
+    - name: zip files
+      run: |
+        cd tidal-listener/
+        tar cvfj binary.tar binary/*
+
+    - name: release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: tidal-listener/binary.tar

--- a/.github/workflows/listener-build-linux.yml
+++ b/.github/workflows/listener-build-linux.yml
@@ -3,7 +3,7 @@ name: build-listener-linux
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "*.*.*"
 
 jobs:
   build:

--- a/.github/workflows/listener-build-macosx.yml
+++ b/.github/workflows/listener-build-macosx.yml
@@ -3,7 +3,7 @@ name: build-listener-macosx
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "*.*.*"
 
 jobs:
   build:

--- a/.github/workflows/listener-build-macosx.yml
+++ b/.github/workflows/listener-build-macosx.yml
@@ -1,0 +1,114 @@
+name: build-listener-macosx
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+
+    runs-on: macOS-latest
+    strategy:
+      matrix:
+        ghc: ['9.0.1']
+        cabal: ['3.4.0.0']
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup Haskell
+        uses: haskell/actions/setup@v1
+        id: setup-haskell-cabal
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+
+      - name: Freeze
+        run: |
+          cabal freeze
+
+      - name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('tidal-listener/src') }}
+
+      - name: cabal update and build
+        run: |
+          cabal update
+          cabal build --enable-tests tidal-listener
+
+      - name: move GHC libs and configs
+        run: |
+          mkdir -p tidal-listener/binary/haskell-libs/ghc-packages/
+          cp -r ${{ steps.setup-haskell-cabal.outputs.ghc-path }}/../lib/ghc-${{ matrix.ghc }}/* tidal-listener/binary/haskell-libs/ghc-packages
+
+      - name: move installed packages
+        run: |
+          mkdir -p tidal-listener/binary/haskell-libs/packages/
+          cp -r ${{ steps.setup-haskell-cabal.outputs.cabal-store }}/ghc-${{ matrix.ghc }}/* tidal-listener/binary/haskell-libs/packages
+          ls tidal-listener/binary/haskell-libs/packages
+
+      - name: change paths in config files (GHC)
+        run: |
+          export LANG=C
+          export LC_CTYPE=C
+          export LC_ALL=C
+          mv tidal-listener/binary/haskell-libs/ghc-packages/package.conf.d tidal-listener/binary/haskell-libs/package.conf.d
+          sed -i '' 's+/Users/runner/.ghcup/ghc/${{ matrix.ghc }}/lib/ghc-${{ matrix.ghc }}+${pkgroot}/ghc-packages+g' tidal-listener/binary/haskell-libs/package.conf.d/*
+
+      - name: change paths in config files (cabal)
+        run: |
+          export LANG=C
+          export LC_CTYPE=C
+          export LC_ALL=C
+          mv tidal-listener/binary/haskell-libs/packages/package.db tidal-listener/binary/haskell-libs/package.db
+          sed -i '' 's+/Users/runner/.cabal/store/ghc-8.10.1+${pkgroot}/packages+g' tidal-listener/binary/haskell-libs/package.db/*
+
+      - name: move ghc settings etc
+        run: |
+          mv tidal-listener/binary/haskell-libs/ghc-packages/settings tidal-listener/binary/haskell-libs/settings
+          mv tidal-listener/binary/haskell-libs/ghc-packages/platformConstants tidal-listener/binary/haskell-libs/platformConstants
+          mv tidal-listener/binary/haskell-libs/ghc-packages/llvm-targets tidal-listener/binary/haskell-libs/llvm-targets
+          mv tidal-listener/binary/haskell-libs/ghc-packages/llvm-passes tidal-listener/binary/haskell-libs/llvm-passes
+
+      - name: ghc-pkg recache
+        run: |
+          ghc-pkg --package-db=tidal-listener/binary/haskell-libs/package.conf.d recache
+          ghc-pkg --package-db=tidal-listener/binary/haskell-libs/package.db recache
+          ghc-pkg --package-db=tidal-listener/binary/haskell-libs/package.conf.d --package-db=tidal-listener/binary/haskell-libs/package.db check
+
+      - name: remove unneccessary libs
+        run: |
+          cd tidal-listener/binary/haskell-libs/ghc-packages
+          rm -r ghc-${{ matrix.ghc }}
+          rm -r Cabal-*
+          rm -R rts
+
+      - name: fake gcc
+        run: |
+          export LANG=C
+          export LC_CTYPE=C
+          export LC_ALL=C
+          mkdir -p tidal-listener/binary/haskell-libs/bin/
+          cp -r tidal-listener/fake_gcc.sh tidal-listener/binary/haskell-libs/bin/fake_gcc.sh
+          sed -i '' 's+gcc+$topdir/bin/fake_gcc.sh+g' tidal-listener/binary/haskell-libs/settings
+          chmod 755 tidal-listener/binary/haskell-libs/bin/fake_gcc.sh
+
+      - name: move executable
+        run: cp -r dist-newstyle/build/x86_64-osx/ghc-${{ matrix.ghc }}/tidal-listener-0.1.0.0/x/tidal-listener/build/tidal-listener/tidal-listener tidal-listener/binary/tidal-listener
+
+      - name: zip files
+        run: |
+          cd tidal-listener/
+          tar cvfj macOS.tar binary/*
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: tidal-listener/macOS.tar

--- a/.github/workflows/listener-build-windows.yml
+++ b/.github/workflows/listener-build-windows.yml
@@ -3,7 +3,7 @@ name: build-listener-windows
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "*.*.*"
 
 jobs:
   build:

--- a/.github/workflows/listener-build-windows.yml
+++ b/.github/workflows/listener-build-windows.yml
@@ -1,0 +1,94 @@
+name: build-listener-windows
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        ghc: ['9.0.1']
+        cabal: ['3.4.0.0']
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup Haskell
+        uses: haskell/actions/setup@v1
+        id: setup-haskell-cabal
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+
+      - name: Freeze
+        run: |
+          cabal freeze
+
+      - name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('tidal-listener/src') }}
+
+      - name: cabal build
+        run: |
+          cabal update
+          cabal build --enable-tests tidal-listener
+
+      - name: remove unneccessary libs
+        run: |
+          Remove-Item 'C:\tools\ghc-${{ matrix.ghc }}\lib\ghc-${{ matrix.ghc }}' -Recurse -ErrorAction Ignore
+          Remove-Item 'C:\tools\ghc-${{ matrix.ghc }}\lib\Cabal-*' -Recurse -ErrorAction Ignore
+          Remove-Item 'C:\tools\ghc-${{ matrix.ghc }}\lib\rts' -Recurse -ErrorAction Ignore
+
+      - name: move GHC libs and configs
+        run: |
+          Copy-Item -Path 'C:\tools\ghc-${{ matrix.ghc }}\lib\' -Recurse -Destination 'tidal-listener\binary\haskell-libs\ghc-packages'
+          Move-Item -Path 'tidal-listener\binary\haskell-libs\ghc-packages\settings' -Destination 'tidal-listener\binary\haskell-libs\settings'
+          Move-Item -Path 'tidal-listener\binary\haskell-libs\ghc-packages\llvm-passes' -Destination 'tidal-listener\binary\haskell-libs\llvm-passes'
+          Move-Item -Path 'tidal-listener\binary\haskell-libs\ghc-packages\llvm-targets' -Destination 'tidal-listener\binary\haskell-libs\llvm-targets'
+          Move-Item -Path 'tidal-listener\binary\haskell-libs\ghc-packages\platformConstants' -Destination 'tidal-listener\binary\haskell-libs\platformConstants'
+
+      - name: move mingw
+        run: Copy-Item -Path 'C:\tools\ghc-${{ matrix.ghc }}\mingw\' -Recurse -Destination 'tidal-listener\binary\mingw'
+
+      - name: move installed packages
+        run: Copy-Item -Path 'C:\sr\ghc-${{ matrix.ghc }}\' -Recurse -Destination 'tidal-listener\binary\haskell-libs\packages'
+
+      - name: change paths in config files (packages)
+        run: |
+          Move-Item -Path 'tidal-listener\binary\haskell-libs\packages\package.db\' -Destination 'tidal-listener\binary\haskell-libs\package.db\'
+          $configs = Get-ChildItem 'tidal-listener\binary\haskell-libs\package.db\' -Recurse
+          $configs | %{ (gc $_) -replace "C:\\sr\\ghc-${{ matrix.ghc }}", '$topdir\packages' | Set-Content $_.fullname}
+
+      - name: move ghc package config
+        run: |
+          Move-Item -Path 'tidal-listener\binary\haskell-libs\ghc-packages\package.conf.d\' -Destination 'tidal-listener\binary\haskell-libs\package.conf.d\'
+          $configs = Get-ChildItem 'tidal-listener\binary\haskell-libs\package.conf.d\' -Recurse
+          $configs | %{ (gc $_) -replace 'topdir', 'topdir\ghc-packages' | Set-Content $_.fullname}
+
+      - name: ghc-pkg recache
+        run: |
+          $ENV:GHC_PACKAGE_PATH="tidal-listener\binary\haskell-libs\package.conf.d;tidal-listener\binary\haskell-libs\package.db"
+          ghc-pkg -v2 recache --package-db="tidal-listener\binary\haskell-libs\package.conf.d"
+          ghc-pkg -v2 recache --package-db="tidal-listener\binary\haskell-libs\package.db"
+
+      - name: move executable
+        run: Copy-Item -Path 'dist-newstyle\build\x86_64-windows\ghc-${{ matrix.ghc }}\tidal-listener-0.1.0.0\x\tidal-listener\build\tidal-listener\tidal-listener.exe' -Recurse -Destination 'tidal-listener\binary\tidal-listener.exe'
+
+      - name: zip files
+        run: Compress-Archive -LiteralPath 'tidal-listener\binary\' -DestinationPath 'tidal-listener\windows.zip'
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: 'tidal-listener\windows.zip'

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,1 @@
-packages: ./ tidal-parse
+packages: ./ tidal-parse tidal-listener

--- a/tidal-listener/fake_gcc.sh
+++ b/tidal-listener/fake_gcc.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# hint barely uses gcc at all, only for queries of the following form:
+# 
+#  $ gcc -fno-stack-protector -DTABLES_NEXT_TO_CODE -B/root/my-program/haskell-libs/integ_2aU3IZNMF9a7mQ0OzsZ0dS --print-file-name libgmp.so
+#  libgmp.so
+# 
+# We can easily fake it by always returning the last argument.
+
+while [ "$2" ]; do shift; done
+echo "$1"

--- a/tidal-listener/tidal-listener.cabal
+++ b/tidal-listener/tidal-listener.cabal
@@ -19,11 +19,10 @@ library
   exposed-modules:     Sound.Tidal.Listener
                        Sound.Tidal.Listener.Config
                        Sound.Tidal.Hint
-  build-depends:       base >= 4.7 && < 5,
+  build-depends:       base,
                        data-default,
                        tidal >=1.7.1,
                        hosc,
-                       unix,
                        hint,
                        network
   default-language:    Haskell2010

--- a/tidal-parse/tidal-parse.cabal
+++ b/tidal-parse/tidal-parse.cabal
@@ -33,8 +33,8 @@ library
     , tidal >= 1.7 && <1.8
     , transformers >= 0.5 && < 0.5.7
     , haskell-src-exts >= 1.17.1 && < 1.24
-    , template-haskell >= 2.10.0.0 && < 2.17
-    , haskellish >= 0.2.4.3 && < 0.3
+    , template-haskell
+    , haskellish
     , containers < 0.7
     , mtl >= 2.2.2 && <2.3
     , text < 1.3


### PR DESCRIPTION
Ref #850 and #315 
Adapted from https://github.com/polymorphicengine/tidal-gui
They will run only after a tag with the format `*.*.*`, so only after a tidal release.
Tested on my fork.