### PR TITLE
Use better show instances for notes & rationals

### DIFF
--- a/src/Sound/Tidal/Pattern.hs
+++ b/src/Sound/Tidal/Pattern.hs
@@ -647,8 +647,16 @@ instance NFData Value
 type ValueMap = Map.Map String Value
 
 -- | Note is Double, but with a different parser
-newtype Note = Note { unNote :: Double } deriving (Typeable, Data, Generic, Eq, Ord, Show, Enum, Num, Fractional, Floating, Real)
+newtype Note = Note { unNote :: Double } deriving (Typeable, Data, Generic, Eq, Ord, Enum, Num, Fractional, Floating, Real)
 instance NFData Note
+
+instance Show Note where
+  show n = (show . unNote $ n) ++ "n (" ++ pitchClass ++ octave ++ ")"
+    where
+      pitchClass = pcs !! mod noteInt 12
+      octave = show $ div noteInt 12 + 5
+      noteInt = round . unNote $ n
+      pcs = ["c", "cs", "d", "ds", "e", "f", "fs", "g", "gs", "a", "as", "b"]
 
 instance Valuable String where
   toValue a = VS a

--- a/src/Sound/Tidal/Show.hs
+++ b/src/Sound/Tidal/Show.hs
@@ -78,8 +78,8 @@ instance Show Value where
   show (VS s)  = ('"':s) ++ "\""
   show (VI i)  = show i
   show (VF f)  = show f ++ "f"
-  show (VN n)  = show n ++ "n"
-  show (VR r)  = show r ++ "r"
+  show (VN n)  = show n
+  show (VR r)  = prettyRat r ++ "r"
   show (VB b)  = show b
   show (VX xs) = show xs
   show (VPattern pat) = "(" ++ show pat ++ ")"


### PR DESCRIPTION
In the discussion from #807 it came up that the `Show` instance for notes is a bit confusing, because it exposes the structure of the Note type. I added a new show function that prints the numeric value followed by the note name. Here's what it looks like in the context of a pattern:

```
> n "c d6 20.75 -30"
(0>¼)|n: 0.0n (c5)
(¼>½)|n: 14.0n (d6)
(½>¾)|n: 20.75n (a6)
(¾>1)|n: -30.0n (fs2)
```

I also updated the `Show` instance for patterns to use the prettier rational representation (used by time spans) for rational values.