### PR TITLE
tidal-listener: Separate build from release

### DIFF
--- a/.github/workflows/listener-build-linux.yml
+++ b/.github/workflows/listener-build-linux.yml
@@ -1,9 +1,6 @@
 name: build-listener-linux
 
-on:
-  push:
-    tags:
-      - "*.*.*"
+on: push
 
 jobs:
   build:
@@ -26,8 +23,7 @@ jobs:
         cabal-version: ${{ matrix.cabal }}
         
     - name: Freeze
-      run: |
-        cabal freeze
+      run: cabal freeze
 
     - name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
       uses: actions/cache@v2
@@ -120,7 +116,18 @@ jobs:
         cd tidal-listener/
         tar cvfj binary.tar binary/*
 
-    - name: release
-      uses: softprops/action-gh-release@v1
+    - uses: actions/upload-artifact@v2
       with:
-        files: tidal-listener/binary.tar
+        path: tidal-listener/binary.tar
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+    - uses: actions/download-artifact@v2
+    - run: ls */*
+
+    - uses: softprops/action-gh-release@v1
+      with:
+        files: artifact/binary.tar

--- a/.github/workflows/listener-build-linux.yml
+++ b/.github/workflows/listener-build-linux.yml
@@ -1,6 +1,6 @@
 name: build-listener-linux
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/listener-build-macosx.yml
+++ b/.github/workflows/listener-build-macosx.yml
@@ -1,6 +1,6 @@
 name: build-listener-macosx
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/listener-build-macosx.yml
+++ b/.github/workflows/listener-build-macosx.yml
@@ -1,9 +1,6 @@
 name: build-listener-macosx
 
-on:
-  push:
-    tags:
-      - "*.*.*"
+on: push
 
 jobs:
   build:
@@ -88,7 +85,7 @@ jobs:
           cd tidal-listener/binary/haskell-libs/ghc-packages
           rm -r ghc-${{ matrix.ghc }}
           rm -r Cabal-*
-          rm -R rts
+          rm -r rts
 
       - name: fake gcc
         run: |
@@ -106,9 +103,20 @@ jobs:
       - name: zip files
         run: |
           cd tidal-listener/
-          tar cvfj macOS.tar binary/*
+          tar cvfj macosx.tar binary/*
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
+      - uses: actions/upload-artifact@v2
         with:
-          files: tidal-listener/macOS.tar
+          path: tidal-listener/macosx.tar
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v2
+      - run: ls */*
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: artifact/macosx.tar

--- a/.github/workflows/listener-build-windows.yml
+++ b/.github/workflows/listener-build-windows.yml
@@ -1,9 +1,6 @@
 name: build-listener-windows
 
-on:
-  push:
-    tags:
-      - "*.*.*"
+on: push
 
 jobs:
   build:
@@ -87,8 +84,18 @@ jobs:
       - name: zip files
         run: Compress-Archive -LiteralPath 'tidal-listener\binary\' -DestinationPath 'tidal-listener\windows.zip'
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+      - uses: actions/upload-artifact@v2
         with:
-          files: 'tidal-listener\windows.zip'
+          path: tidal-listener\windows.zip
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v2
+      - run: ls */*
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: artifact/windows.zip

--- a/.github/workflows/listener-build-windows.yml
+++ b/.github/workflows/listener-build-windows.yml
@@ -1,6 +1,6 @@
 name: build-listener-windows
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
I separated the build job from the release job, and the latter would be executed only on a tag.
The artifacts will be available in the action section of the action workflow for 90 days (according to the github actions documentation)