### PR TITLE
deriving typeclass memberships for ID

### DIFF
--- a/src/Sound/Tidal/ID.hs
+++ b/src/Sound/Tidal/ID.hs
@@ -23,7 +23,8 @@ import GHC.Exts ( IsString(..) )
 -- | Wrapper for literals that can be coerced to a string and used as an identifier.
 -- | Similar to Show typeclass, but constrained to strings and integers and designed
 -- | so that similar cases (such as 1 and "1") convert to the same value.
-newtype ID = ID { fromID :: String }
+newtype ID = ID { fromID :: String } deriving (Eq, Show, Ord, Read)
+
 
 noOv :: String -> a
 noOv meth = error $ meth ++ ": not supported for ids"


### PR DESCRIPTION
this would be convenient in some parts of the tidal-gui and I don't really see a reason not to just derive the memberships (?)