### PR TITLE
move tidal-listener code

### DIFF
--- a/tidal-listener/src/Sound/Tidal/Hint.hs
+++ b/tidal-listener/src/Sound/Tidal/Hint.hs
@@ -2,11 +2,13 @@ module Sound.Tidal.Hint where
 
 import           Control.Exception
 import           Language.Haskell.Interpreter as Hint
+import           Language.Haskell.Interpreter.Unsafe as Hint
 import           Sound.Tidal.Context
 import           System.IO
 import           Control.Concurrent.MVar
 import           Data.List (intercalate,isPrefixOf)
 import           Sound.Tidal.Utils
+import           System.Environment(getEnv)
 
 data Response = HintOK {parsed :: ControlPattern}
               | HintError {errorMessage :: String}
@@ -53,18 +55,45 @@ libs = [
 
 exts = [OverloadedStrings, NoImplicitPrelude]
 
-hintControlPattern  :: String -> IO (Either InterpreterError ControlPattern)
-hintControlPattern s = Hint.runInterpreter $ do
-  Hint.set [languageExtensions := exts]
-  Hint.setImports libs
-  Hint.interpret s (Hint.as :: ControlPattern)
+ghcArgs:: [String]
+ghcArgs = ["-clear-package-db", "-package-db", "haskell-libs/package.conf.d", "-package-db", "haskell-libs/package.db", "-v"]
 
-hintJob  :: MVar String -> MVar Response -> IO ()
-hintJob mIn mOut =
-  do result <- catch (do Hint.runInterpreter $ do
+hintControlPattern  :: String -> IO (Either InterpreterError ControlPattern)
+hintControlPattern s = do
+  env <- getEnv "WITH_GHC"
+  case env of
+    "FALSE" -> do
+        Hint.unsafeRunInterpreterWithArgsLibdir ghcArgs "haskell-libs" $ do
+              Hint.set [languageExtensions := exts]
+              Hint.setImports libs
+              Hint.interpret s (Hint.as :: ControlPattern)
+    _ -> do
+        Hint.runInterpreter $ do
+          Hint.set [languageExtensions := exts]
+          Hint.setImports libs
+          Hint.interpret s (Hint.as :: ControlPattern)
+
+hintLoop :: MonadInterpreter m => MVar String -> MVar Response -> m b
+hintLoop mIn mOut = do s <- liftIO (readMVar mIn)
+                       let munged = deltaMini s
+                       t <- Hint.typeChecksWithDetails munged
+                       interp t munged
+                       hintLoop mIn mOut
+             where interp (Left errors) _ = do liftIO $ do putMVar mOut $ HintError $ "Didn't typecheck " ++ concatMap show errors
+                                                           hPutStrLn stderr $ "error: " ++ concatMap show errors
+                                                           takeMVar mIn
+                                                           return ()
+                   interp (Right t) s = do p <- Hint.interpret s (Hint.as :: ControlPattern)
+                                           liftIO $ putMVar mOut $ HintOK p
+                                           liftIO $ takeMVar mIn
+                                           return ()
+
+hintJobUnsafe :: MVar String -> MVar Response -> IO ()
+hintJobUnsafe mIn mOut =
+  do result <- catch (do Hint.unsafeRunInterpreterWithArgsLibdir ghcArgs "haskell-libs" $ do
                            Hint.set [languageExtensions := exts]
                            Hint.setImports libs
-                           hintLoop
+                           hintLoop mIn mOut
                      )
                (\e -> return (Left $ UnknownError $ "exception" ++ show (e :: SomeException)))
      let response = case result of
@@ -77,18 +106,33 @@ hintJob mIn mOut =
 
      takeMVar mIn
      putMVar mOut response
-     hintJob mIn mOut
-     where hintLoop = do s <- liftIO (readMVar mIn)
-                         let munged = deltaMini s
-                         t <- Hint.typeChecksWithDetails munged
-                         interp t munged
-                         hintLoop
-           interp (Left errors) _ = do liftIO $ do putMVar mOut $ HintError $ "Didn't typecheck " ++ concatMap show errors
-                                                   hPutStrLn stderr $ "error: " ++ concatMap show errors
-                                                   takeMVar mIn
-                                       return ()
-           interp (Right t) s =
-             do p <- Hint.interpret s (Hint.as :: ControlPattern)
-                liftIO $ putMVar mOut $ HintOK p
-                liftIO $ takeMVar mIn
-                return ()
+     hintJobUnsafe mIn mOut
+
+
+
+hintJobSafe  :: MVar String -> MVar Response -> IO ()
+hintJobSafe mIn mOut =
+  do result <- catch (do Hint.runInterpreter $ do
+                           Hint.set [languageExtensions := exts]
+                           Hint.setImports libs
+                           hintLoop mIn mOut
+                     )
+               (\e -> return (Left $ UnknownError $ "exception" ++ show (e :: SomeException)))
+     let response = case result of
+          Left err -> HintError (parseError err)
+          Right p  -> HintOK p -- can happen
+         parseError (UnknownError s) = "Unknown error: " ++ s
+         parseError (WontCompile es) = "Compile error: " ++ (intercalate "\n" (Prelude.map errMsg es))
+         parseError (NotAllowed s) = "NotAllowed error: " ++ s
+         parseError (GhcException s) = "GHC Exception: " ++ s
+
+     takeMVar mIn
+     putMVar mOut response
+     hintJobSafe mIn mOut
+
+hintJob :: MVar String -> MVar Response -> IO ()
+hintJob mIn mOut = do
+        env <- getEnv "WITH_GHC"
+        case env of
+          "FALSE" -> hintJobUnsafe mIn mOut
+          _ -> hintJobSafe mIn mOut

--- a/tidal-listener/src/Sound/Tidal/Listener.hs
+++ b/tidal-listener/src/Sound/Tidal/Listener.hs
@@ -13,6 +13,7 @@ import Control.Concurrent
 import Control.Concurrent.MVar
 import qualified Network.Socket as N
 import qualified Sound.Tidal.Tempo as Tempo
+import System.Environment(getEnv)
 
 {-
 https://github.com/tidalcycles/tidal-listener/wiki
@@ -34,10 +35,13 @@ listen = listenWithConfig def
 -- | Configurable variant of @listen@
 listenWithConfig :: ListenerConfig -> IO ()
 listenWithConfig ListenerConfig{..} = do
+            env <- getEnv "WITH_GHC"
+            let mode = if env /= "FALSE" then "with-ghc-mode" else "without-ghc-mode"
             (mIn, mOut) <- startHint
             -- listen
             (remote_addr:_) <- N.getAddrInfo Nothing (Just "127.0.0.1") Nothing
             local <- udpServer "127.0.0.1" listenPort
+            putStrLn $ "Starting Tidal Listener in " ++ mode
             putStrLn $ "Listening for OSC commands on port " ++ show listenPort
             putStrLn $ "Sending replies to port " ++ show remotePort
             putStrLn "Starting tidal interpreter.. "
@@ -78,17 +82,17 @@ getcps st = do tempo <- readMVar $ T.sTempoMV (sStream st)
 
 act :: State -> Maybe O.Message -> IO State
 act st (Just (Message "/code" [ASCII_String a_ident, ASCII_String a_code])) =
-  do let ident = ascii_to_string a_ident
+  do let ident = ID $ ascii_to_string a_ident
          code = ascii_to_string a_code
      putMVar (sIn st) code
      r <- takeMVar (sOut st)
      respond ident r
      return st
        where respond ident (HintOK pat) =
-               do T.streamReplace (sStream st) (ID ident) pat
-                  O.sendTo (sLocal st) (O.p_message "/code/ok" [string ident]) (sRemote st)
+               do T.streamReplace (sStream st) ident pat
+                  O.sendTo (sLocal st) (O.p_message "/code/ok" [string $ fromID ident]) (sRemote st)
              respond ident (HintError s) =
-               O.sendTo (sLocal st) (O.p_message "/code/error" [string ident, string s]) (sRemote st)
+               O.sendTo (sLocal st) (O.p_message "/code/error" [string $ fromID ident, string s]) (sRemote st)
 
 act st (Just (Message "/ping" [])) =
   do O.sendTo (sLocal st) (O.p_message "/pong" []) (sRemote st)


### PR DESCRIPTION
adds support for running tidal-listener without ghc and fixes a small issue with the new ID type