### PR TITLE
Define the Eq and Ord instances for the Event type by hand,

### DIFF
--- a/src/Sound/Tidal/Pattern.hs
+++ b/src/Sound/Tidal/Pattern.hs
@@ -555,7 +555,18 @@ data EventF a b = Event
   , whole :: Maybe a
   , part :: a
   , value :: b
-  } deriving (Eq, Ord, Functor, Generic)
+  } deriving (Functor, Generic)
+
+-- | Ignore the `context` field when comparing `Event`s.
+instance (Eq a, Eq b) => Eq (EventF a b) where
+  (==) x y = let relevant e = (part e, value e, whole e)
+             in relevant x == relevant y
+
+-- | Ignore the `context` field when comparing `Event`s.
+instance (Ord a, Ord b) => Ord (EventF a b) where
+  (<=) x y = let relevant e = (part e, value e, whole e)
+             in relevant x <= relevant y
+
 instance (NFData a, NFData b) => NFData (EventF a b)
 
 type Event a = EventF (ArcF Time) a

--- a/test/Sound/Tidal/PatternTest.hs
+++ b/test/Sound/Tidal/PatternTest.hs
@@ -23,6 +23,25 @@ run =
         let res = fmap (+1) (Arc 3 5)
         property $ ((Arc 4 6) :: Arc) === res
 
+    describe "Some non-derived Event instances (missing: NFData)" $ do
+      let e = Event { context = Context []
+                    , whole = Just 0
+                    , part = 0
+                    , value = 0 }
+          f = e { context = Context $ [((1,1),(1,1))] }
+      describe "Eq: Context is irrelevant to Event equality (and everything else is relevant)" $
+        and [ e == f
+            , e /= e { whole   = Just 1 }
+            , e /= e { part    = 1 }
+            , e /= e { value   = 1 } ]
+      describe "Ord: Context is irrelevant to Event ordering (and everything else is relevant)" $
+        and [ e < f { whole = Just 1 }
+            , f < e { whole = Just 1 }
+            , e < f { part  = 1 }
+            , f < e { part  = 1 }
+            , e < f { value = 1 }
+            , f < e { value = 1 } ]
+
   {-
     describe "Event" $ do
       it "(Bifunctor) first: Apply a function to the Arc elements: whole and part" $ do


### PR DESCRIPTION
  so that otherwise-equal Events are considered equal
  even if their Contexts (debugging information) differ.