### PR TITLE
Define the Eq and Ord instances for the Event type by hand,

### DIFF
--- a/src/Sound/Tidal/Pattern.hs
+++ b/src/Sound/Tidal/Pattern.hs
@@ -55,7 +55,16 @@ data State = State {arc :: Arc,
 
 -- | A datatype representing events taking place over time
 data Pattern a = Pattern {query :: State -> [Event a]}
-  deriving (Generic, Functor)
+  } deriving (Functor, Generic)
+
+instance (Eq a, Eq b) => Eq (EventF a b) where
+  (==) x y = let relevant e = (whole e, part e, value e)
+             in relevant x == relevant y
+
+instance (Ord a, Ord b) => Ord (EventF a b) where
+  (<=) x y = let relevant e = (whole e, part e, value e)
+             in relevant x <= relevant y
+
 
 instance NFData a => NFData (Pattern a)
 
@@ -341,7 +350,7 @@ empty :: Pattern a
 empty = Pattern {query = const []}
 
 queryArc :: Pattern a -> Arc -> [Event a]
-queryArc p a = query p $ State a Map.empty 
+queryArc p a = query p $ State a Map.empty
 
 -- | Splits queries that span cycles. For example `query p (0.5, 1.5)` would be
 -- turned into two queries, `(0.5,1)` and `(1,1.5)`, and the results
@@ -422,7 +431,7 @@ compressArcTo (Arc s e) = compressArc (Arc (cyclePos s) (e - sam s))
 
 _fastGap :: Time -> Pattern a -> Pattern a
 _fastGap 0 _ = empty
-_fastGap r p = splitQueries $ 
+_fastGap r p = splitQueries $
   withResultArc (\(Arc s e) -> Arc (sam s + ((s - sam s)/r'))
                              (sam s + ((e - sam s)/r'))
                  ) $ p {query = f}
@@ -555,7 +564,16 @@ data EventF a b = Event
   , whole :: Maybe a
   , part :: a
   , value :: b
-  } deriving (Eq, Ord, Functor, Generic)
+  } deriving (Functor, Generic)
+
+instance (Eq a, Eq b) => Eq (EventF a b) where
+  (==) x y = let relevant e = (whole e, part e, value e)
+             in relevant x == relevant y
+
+instance (Ord a, Ord b) => Ord (EventF a b) where
+  (<=) x y = let relevant e = (whole e, part e, value e)
+             in relevant x <= relevant y
+
 instance (NFData a, NFData b) => NFData (EventF a b)
 
 type Event a = EventF (ArcF Time) a

--- a/test/Sound/Tidal/PatternTest.hs
+++ b/test/Sound/Tidal/PatternTest.hs
@@ -23,6 +23,25 @@ run =
         let res = fmap (+1) (Arc 3 5)
         property $ ((Arc 4 6) :: Arc) === res
 
+    describe "the Event type's" $ do
+      let e = Event { context = Context []
+                    , whole = Just 0
+                    , part = 0
+                    , value = 0 }
+          f = e { context = Context $ [((1,1),(1,1))] }
+      describe "Eq instance" $
+        and [ e == f
+            , e /= e { whole   = Just 1 }
+            , e /= e { part    = 1 }
+            , e /= e { value   = 1 } ]
+      describe "Ord instance" $
+        and [ e < f { whole = Just 1 }
+            , f < e { whole = Just 1 }
+            , e < f { part  = 1 }
+            , f < e { part  = 1 }
+            , e < f { value = 1 }
+            , f < e { value = 1 } ]
+
   {-
     describe "Event" $ do
       it "(Bifunctor) first: Apply a function to the Arc elements: whole and part" $ do


### PR DESCRIPTION
  This way, otherwise-equal `Event`s are considered equal
  even if their `Context`s (debugging information) differ.
  Also, `Event`s are compared first on when they happen
  (the `part` field), second on their `value`,
  and only last on their `whole` field (which is often `Nothing`).
  Sorting a `List` of `Event`s will thus cause the early ones
  to be first in the `List`, and contemporaneous ones
  to be adjacent in the list even if their `whole`s differ.