### PR TITLE
tidal-listener: Add minimal install notes

### DIFF
--- a/tidal-listener/README.md
+++ b/tidal-listener/README.md
@@ -1,6 +1,14 @@
 # tidal-listener
 Experimental tidal OSC listener.
 
+## Install
+
+Move to the repository directory and run `cabal install`. 
+
+On Linux systems, the `tidal-listener` binary will be found inside `~/.cabal/bin/`.
+
+## Protocol
+
 This is a work-in-progress and the below is not yet implemented.
 
 Basic protocol ideas (`>`, incoming message `<`, outgoing message)


### PR DESCRIPTION
I was able to piece out this information from a couple of Github issues, and maybe the README's the place for that?