### PR TITLE
Add parsers for ints and floats that don't consume trailing whitespace

### DIFF
--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -324,9 +324,7 @@ sign  =  do char '-'
          <|> return Positive
 
 intOrFloat :: MyParser Double
-intOrFloat = do -- use 'try' to avoid consuming the first '.' in a '..' range.
-                try float
-                <|> fromIntegral <$> integer
+intOrFloat = try pFloat <|> pInteger
 
 pSequence :: Parseable a => MyParser (TPat a) -> MyParser (TPat a)
 pSequence f = do
@@ -562,7 +560,7 @@ pRational = wrapPos $ TPat_Atom Nothing <$> pRatio
 pRatio :: MyParser Rational
 pRatio = do
   s <- sign
-  r <- do n <- try (try pFloat <|> pInteger)
+  r <- do n <- try intOrFloat
           v <- pFraction n <|> return (toRational n)
           r <- pRatioChar <|> return 1
           return (v * r)

--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -575,7 +575,6 @@ pInteger = read <$> many1 digit
 
 pFloat :: MyParser Double
 pFloat = do
-<<<<<<< HEAD
         i <- many1 digit
         d <- option "0" (char '.' >> many1 digit)
         e <- option "0" (char 'e' >> do
@@ -583,11 +582,6 @@ pFloat = do
                                     e' <- many1 digit
                                     return $ s++e')
         return $ read (i++"."++d++"e"++e)
-=======
-        x <- many1 digit
-        y <- option "0" (char '.' >> many1 digit)
-        return $ read (x++"."++y)
->>>>>>> 8ba3f35149ba0ac1e567ba6bf730b32b4ee93d1f
 
 pFraction :: RealFrac a => a -> MyParser Rational
 pFraction n = do

--- a/test/Sound/Tidal/ParseTest.hs
+++ b/test/Sound/Tidal/ParseTest.hs
@@ -207,4 +207,12 @@ run =
       it "can't parse a floating point number as int" $ do
         evaluate ("1.5" :: Pattern Int)
           `shouldThrow` anyException
+      it "can correctly parse multiplied boolean patterns 1" $ do
+        compareP (Arc 0 1)
+          ("t*2 t*3" :: Pattern Bool)
+          ("1*2 1*3" :: Pattern Bool)
+      it "can correctly parse multiplied boolean patterns 2" $ do
+        compareP (Arc 0 1)
+          ("t*2t t" :: Pattern Bool)
+          ("1*2%3 1" :: Pattern Bool)
     where degradeByDefault = _degradeBy 0.5

--- a/test/Sound/Tidal/UITest.hs
+++ b/test/Sound/Tidal/UITest.hs
@@ -136,7 +136,7 @@ run =
           (queryArc (irand 10) (Arc 0.25 0.25)) `shouldBe` [Event (Context []) Nothing (Arc 0.25 0.25) (6 :: Int)]
         it "is patternable" $
           (queryArc (irand "10 2") (Arc 0 1)) `shouldBe` [
-            Event (Context [((1,1),(4,1))]) Nothing (Arc 0 0.5) (6 :: Int), Event (Context [((4,1),(5,1))]) Nothing (Arc 0.5 1) (0 :: Int)
+            Event (Context [((1,1),(3,1))]) Nothing (Arc 0 0.5) (6 :: Int), Event (Context [((4,1),(5,1))]) Nothing (Arc 0.5 1) (0 :: Int)
           ]
 
     describe "range" $ do


### PR DESCRIPTION
Fixes #897 
The problem was that the built in `integer` and `float` parsers consume trailing whitespace, and thus seperating different expressions by whitespace was not possible.