### PR TITLE
tidal-listener: Optional WITH_GHC environment variable

### DIFF
--- a/tidal-listener/src/Sound/Tidal/Hint.hs
+++ b/tidal-listener/src/Sound/Tidal/Hint.hs
@@ -8,7 +8,7 @@ import           System.IO
 import           Control.Concurrent.MVar
 import           Data.List (intercalate,isPrefixOf)
 import           Sound.Tidal.Utils
-import           System.Environment(getEnv)
+import           System.Environment(lookupEnv)
 
 data Response = HintOK {parsed :: ControlPattern}
               | HintError {errorMessage :: String}
@@ -60,9 +60,9 @@ ghcArgs = ["-clear-package-db", "-package-db", "haskell-libs/package.conf.d", "-
 
 hintControlPattern  :: String -> IO (Either InterpreterError ControlPattern)
 hintControlPattern s = do
-  env <- getEnv "WITH_GHC"
+  env <- lookupEnv "WITH_GHC"
   case env of
-    "FALSE" -> do
+    Just "FALSE" -> do
         Hint.unsafeRunInterpreterWithArgsLibdir ghcArgs "haskell-libs" $ do
               Hint.set [languageExtensions := exts]
               Hint.setImports libs
@@ -132,7 +132,7 @@ hintJobSafe mIn mOut =
 
 hintJob :: MVar String -> MVar Response -> IO ()
 hintJob mIn mOut = do
-        env <- getEnv "WITH_GHC"
+        env <- lookupEnv "WITH_GHC"
         case env of
-          "FALSE" -> hintJobUnsafe mIn mOut
+          Just "FALSE" -> hintJobUnsafe mIn mOut
           _ -> hintJobSafe mIn mOut

--- a/tidal-listener/src/Sound/Tidal/Listener.hs
+++ b/tidal-listener/src/Sound/Tidal/Listener.hs
@@ -13,7 +13,7 @@ import Control.Concurrent
 import Control.Concurrent.MVar
 import qualified Network.Socket as N
 import qualified Sound.Tidal.Tempo as Tempo
-import System.Environment(getEnv)
+import System.Environment(lookupEnv)
 
 {-
 https://github.com/tidalcycles/tidal-listener/wiki
@@ -35,8 +35,8 @@ listen = listenWithConfig def
 -- | Configurable variant of @listen@
 listenWithConfig :: ListenerConfig -> IO ()
 listenWithConfig ListenerConfig{..} = do
-            env <- getEnv "WITH_GHC"
-            let mode = if env /= "FALSE" then "with-ghc-mode" else "without-ghc-mode"
+            env <- lookupEnv "WITH_GHC"
+            let mode = if env /= (Just "FALSE") then "with-ghc-mode" else "without-ghc-mode"
             (mIn, mOut) <- startHint
             -- listen
             (remote_addr:_) <- N.getAddrInfo Nothing (Just "127.0.0.1") Nothing


### PR DESCRIPTION
Given that the value of the `WITH_GHC` environment variable is only used when disabling GHC (`WITH_GHC=FALSE`), it makes sense that variable should be optional. Looking through issues, this has tripped a couple of people up.

Fixes #896
Fixes #849 