### PR TITLE
Introduce `echo` and `echoWith`, deprecate `stut` and `stutWith`

### DIFF
--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -1557,12 +1557,6 @@ while b f pat = sew b (f pat) pat
 stutter :: Integral i => i -> Time -> Pattern a -> Pattern a
 stutter n t p = stack $ map (\i -> (t * fromIntegral i) `rotR` p) [0 .. (n-1)]
 
-echo, triple, quad, double :: Time -> Pattern a -> Pattern a
-echo   = stutter (2 :: Int)
-triple = stutter (3 :: Int)
-quad   = stutter (4 :: Int)
-double = echo
-
 {- | The `jux` function creates strange stereo effects, by applying a
 function to a pattern, but only in the right-hand channel. For
 example, the following reverses the pattern on the righthand side:

--- a/test/Sound/Tidal/ControlTest.hs
+++ b/test/Sound/Tidal/ControlTest.hs
@@ -15,6 +15,19 @@ import Sound.Tidal.Pattern
 run :: Microspec ()
 run =
   describe "Sound.Tidal.Control" $ do
+
+    describe "echo" $ do
+      it "should echo the event by the specified time and multiply the gain factor" $ do
+        compareP (Arc 0 1)
+          (echo 2 0.25 0.5 $ s "bd" # gain "1")
+          (stack [rotR 0 "bd" # gain 1, rotR 0.25 "bd" # gain 0.5])
+
+    describe "echoWith" $ do
+      it "should echo the event by the specified time and apply the specified function" $ do
+        compareP (Arc 0 1)
+          (echoWith 2 0.25 (|* speed 2) $ s "bd" # speed "1")
+          (stack [rotR 0 "bd" # speed 1, rotR 0.25 "bd" # speed 2])
+
     describe "stutWith" $ do
       it "can mimic stut" $ do
         comparePD (Arc 0 1)


### PR DESCRIPTION
Fix #902

* Remove `echo`, `triple`, `quad`, `double` aliases as seems like they are not used a lot (nor documented)
* Add `echo` and `echoWith` that have a more consistent signature than `stut` and `stutWith`, that will be removed.
* The `echo` function, unlike `stut`, applies only a simple gain multiplication on every step, as reported in the documentation.

Warning: this PR contains breaking changes