### PR TITLE
Fix echo

### DIFF
--- a/src/Sound/Tidal/Control.hs
+++ b/src/Sound/Tidal/Control.hs
@@ -350,21 +350,21 @@ smash' n xs p = slowcat $ map (`slow` p') xs
 
     This adds a bit of echo:
     @
-    d1 $ echo 4 0.5 0.2 $ sound "bd sn"
+    d1 $ echo 4 0.2 0.5 $ sound "bd sn"
     @
 
     The above results in 4 echos, each one 50% quieter than the last, with 1/5th of a cycle between them.
 
     It is possible to reverse the echo:
     @
-    d1 $ echo 4 0.5 (-0.2) $ sound "bd sn"
+    d1 $ echo 4 (-0.2) 0.5 $ sound "bd sn"
     @
 -}
 echo :: Pattern Integer -> Pattern Rational -> Pattern Double -> ControlPattern -> ControlPattern
 echo = tParam3 _echo
 
 _echo :: Integer -> Rational -> Double -> ControlPattern -> ControlPattern
-_echo count time feedback p = stack (p:map (\x -> ((x%1)*time) `rotR` (p |* P.gain (pure $ (* feedback) (fromIntegral x)))) [1..(count-1)])
+_echo count time feedback p = _echoWith count time (|* P.gain (pure $ feedback)) p
 
 {- |
     Allows to apply a function for each step and overlays the result delayed by the given time.

--- a/src/Sound/Tidal/Pattern.hs
+++ b/src/Sound/Tidal/Pattern.hs
@@ -37,7 +37,7 @@ import           Control.DeepSeq (NFData)
 import           Control.Monad ((>=>))
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (isJust, fromJust, catMaybes, mapMaybe)
-import           Data.List (delete, findIndex, sort)
+import           Data.List (delete, findIndex)
 import           Data.Word (Word8)
 import           Data.Data (Data) -- toConstr
 import           Data.Typeable (Typeable)
@@ -572,11 +572,6 @@ isDigital = not . isAnalog
 -- | `True` if an `Event`'s starts is within given `Arc`
 onsetIn :: Arc -> Event a -> Bool
 onsetIn a e = isIn a (wholeStart e)
-
--- | Compares two lists of events, attempting to combine fragmented events in the process
--- for a 'truer' compare
-compareDefrag :: (Ord a) => [Event a] -> [Event a] -> Bool
-compareDefrag as bs = sort (defragParts as) == sort (defragParts bs)
 
 -- | Returns a list of events, with any adjacent parts of the same whole combined
 defragParts :: Eq a => [Event a] -> [Event a]

--- a/test/Sound/Tidal/ControlTest.hs
+++ b/test/Sound/Tidal/ControlTest.hs
@@ -18,15 +18,23 @@ run =
 
     describe "echo" $ do
       it "should echo the event by the specified time and multiply the gain factor" $ do
-        compareP (Arc 0 1)
-          (echo 2 0.25 0.5 $ s "bd" # gain "1")
-          (stack [rotR 0 "bd" # gain 1, rotR 0.25 "bd" # gain 0.5])
+        comparePD (Arc 0 1)
+          (echo 3 0.2 0.5 $ s "bd" # gain "1")
+          (stack [
+            rotR 0 $ s "bd" # gain 1,
+            rotR 0.2 $ s "bd" # gain 0.5,
+            rotR 0.4 $ s "bd" # gain 0.25
+          ])
 
     describe "echoWith" $ do
       it "should echo the event by the specified time and apply the specified function" $ do
-        compareP (Arc 0 1)
-          (echoWith 2 0.25 (|* speed 2) $ s "bd" # speed "1")
-          (stack [rotR 0 "bd" # speed 1, rotR 0.25 "bd" # speed 2])
+        comparePD (Arc 0 1)
+          (echoWith 3 0.25 (|* speed 2) $ s "bd" # speed "1")
+          (stack [
+            rotR 0 $ s "bd" # speed 1,
+            rotR 0.25 $ s "bd" # speed 2,
+            rotR 0.5 $ s "bd" # speed 4
+          ])
 
     describe "stutWith" $ do
       it "can mimic stut" $ do

--- a/test/Sound/Tidal/PatternTest.hs
+++ b/test/Sound/Tidal/PatternTest.hs
@@ -428,17 +428,6 @@ run =
         let res = defragParts [(Event (Context []) (Just $ Arc 1 2) (Arc 3 4) 5), (Event (Context []) (Just $ Arc 7 8) (Arc 4 3) (5 :: Int))]
         property $ [Event (Context []) (Just $ Arc 1 2) (Arc 3 4) 5, Event (Context []) (Just $ Arc 7 8) (Arc 4 3) (5 :: Int)] === res
 
-    describe "compareDefrag" $ do 
-      it "compare list with Events with empty list of Events" $ do
-        let res = compareDefrag [Event (Context []) (Just $ Arc 1 2) (Arc 3 4) (5 :: Int), Event (Context []) (Just $ Arc 1 2) (Arc 4 3) (5 :: Int)] []
-        property $ False === res 
-      it "compare lists containing same Events but of different length" $ do 
-        let res = compareDefrag [Event (Context []) (Just $ Arc 1 2) (Arc 3 4) (5 :: Int), Event (Context []) (Just $ Arc 1 2) (Arc 4 3) 5] [Event (Context []) (Just $ Arc 1 2) (Arc 3 4) (5 :: Int)]
-        property $ True === res
-      it "compare lists of same length with same Events" $ do 
-        let res = compareDefrag [Event (Context []) (Just $ Arc 1 2) (Arc 3 4) (5 :: Int)] [Event (Context []) (Just $ Arc 1 2) (Arc 3 4) (5 :: Int)]
-        property $ True === res 
-
     describe "sect" $ do 
       it "take two Arcs and return - Arc (max of two starts) (min of two ends)" $ do
         let res = sect (Arc 2.2 3) (Arc 2 2.9)

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -36,13 +36,17 @@ instance TolerantEq (Event ValueMap) where
 
 -- | Compare the events of two patterns using the given arc
 compareP :: (Ord a, Show a) => Arc -> Pattern a -> Pattern a -> Property
-compareP a p p' = (sort $ query (stripContext p) $ State a Map.empty) `shouldBe` (sort $ query (stripContext p') $ State a Map.empty)
+compareP a p p' =
+  (sort $ query (stripContext p) $ State a Map.empty)
+  `shouldBe`
+  (sort $ query (stripContext p') $ State a Map.empty)
 
 -- | Like @compareP@, but tries to 'defragment' the events
-comparePD :: (Ord a) => Arc -> Pattern a -> Pattern a -> Bool
-comparePD a p p' = compareDefrag es es'
-  where es = query (stripContext p) (State a Map.empty)
-        es' = query (stripContext p') (State a Map.empty)
+comparePD :: (Ord a, Show a) => Arc -> Pattern a -> Pattern a -> Property
+comparePD a p p' =
+  (sort $ defragParts $ query (stripContext p) (State a Map.empty))
+  `shouldBe`
+  (sort $ defragParts $ query (stripContext p') (State a Map.empty))
 
 -- | Like @compareP@, but for control patterns, with some tolerance for floating point error
 compareTol :: Arc -> ControlPattern -> ControlPattern -> Bool

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -37,16 +37,16 @@ instance TolerantEq (Event ValueMap) where
 -- | Compare the events of two patterns using the given arc
 compareP :: (Ord a, Show a) => Arc -> Pattern a -> Pattern a -> Property
 compareP a p p' =
-  (sort $ query (stripContext p) $ State a Map.empty)
+  (sort $ queryArc (stripContext p) a)
   `shouldBe`
-  (sort $ query (stripContext p') $ State a Map.empty)
+  (sort $ queryArc (stripContext p') a)
 
 -- | Like @compareP@, but tries to 'defragment' the events
 comparePD :: (Ord a, Show a) => Arc -> Pattern a -> Pattern a -> Property
 comparePD a p p' =
-  (sort $ defragParts $ query (stripContext p) (State a Map.empty))
+  (sort $ defragParts $ queryArc (stripContext p) a)
   `shouldBe`
-  (sort $ defragParts $ query (stripContext p') (State a Map.empty))
+  (sort $ defragParts $ queryArc (stripContext p') a)
 
 -- | Like @compareP@, but for control patterns, with some tolerance for floating point error
 compareTol :: Arc -> ControlPattern -> ControlPattern -> Bool

--- a/tidal-parse/test/Sound/Tidal/TidalParseTest.hs
+++ b/tidal-parse/test/Sound/Tidal/TidalParseTest.hs
@@ -14,7 +14,7 @@ stripContext = setContext $ Context []
 parsesTo :: String -> ControlPattern -> Property
 parsesTo str p = x `shouldBe` y
   where x = query . stripContext <$> parseTidal str <*> Right (State (Arc 0 16) Map.empty)
-        y = Right $ query (stripContext p) $ State (Arc 0 16) Map.empty
+        y = Right $ queryArc (stripContext p) (Arc 0 16)
 
 causesParseError :: String -> Property
 causesParseError str = isLeft (parseTidal str :: Either String ControlPattern) `shouldBe` True


### PR DESCRIPTION
As reported on discord, the first version of `echo` introduced in 1.8.0 is not working correctly, this PR fixes it.

As an addiction, made also `comparePD` print out the detail on failure.

@yaxu at this point, is `compareDefrag` still useful? Seemed to be used only for testing purposes, but at this point it's not used by anyone

@cleary please take a look at this