### PR TITLE
Use target latency in all send modes

### DIFF
--- a/BootTidal.hs
+++ b/BootTidal.hs
@@ -6,7 +6,7 @@ import Sound.Tidal.Context
 import System.IO (hSetEncoding, stdout, utf8)
 hSetEncoding stdout utf8
 
-tidal <- startTidal (superdirtTarget {oLatency = 0.1, oAddress = "127.0.0.1", oPort = 57120}) (defaultConfig {cVerbose = True, cFrameTimespan = 1/20})
+tidal <- startTidal (superdirtTarget {oLatency = 0.05, oAddress = "127.0.0.1", oPort = 57120}) (defaultConfig {cVerbose = True, cFrameTimespan = 1/20})
 
 :{
 let only = (hush >>)

--- a/src/Sound/Tidal/Config.hs
+++ b/src/Sound/Tidal/Config.hs
@@ -45,7 +45,7 @@ defaultConfig = Config {cCtrlListen = True,
                         cCtrlBroadcast = False,
                         cFrameTimespan = 1/20,
                         cEnableLink = True,
-                        cProcessAhead = 1/4,
+                        cProcessAhead = 3/10,
                         cTempoAddr = "127.0.0.1",
                         cTempoPort = 9160,
                         cTempoClientPort = 0, -- choose at random


### PR DESCRIPTION
Enables moving the scheduling of tidal, back and foreward on the Ableton Link timelime.

As requested in #660.