### PR TITLE
overhaul of the chord parser

### DIFF
--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -78,7 +78,7 @@ data TPat a where
    TPat_Repeat :: Int -> (TPat a) -> (TPat a)
    TPat_EnumFromTo :: (TPat a) -> (TPat a) -> (TPat a)
    TPat_Var :: String -> (TPat a)
-   TPat_Chord :: (Num a, Enum a, Parseable a, Enumerable a) => (a -> b) -> (TPat a) -> (TPat String) -> [TPat [Modifier]] -> (TPat b)
+   TPat_Chord :: (Num b, Enum b, Parseable b, Enumerable b) => (b -> a) -> (TPat b) -> (TPat String) -> [TPat [Modifier]] -> (TPat a)
 
 instance Show a => Show (TPat a) where
   show = tShow

--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -81,7 +81,22 @@ data TPat a where
    TPat_Chord :: (Num b, Enum b, Parseable b, Enumerable b) => (b -> a) -> (TPat b) -> (TPat String) -> [TPat [Modifier]] -> (TPat a)
 
 instance Show a => Show (TPat a) where
-  show = tShow
+  show (TPat_Atom c v) = "TPat_Atom (" ++ show c ++ ") (" ++ show v ++ ")"
+  show (TPat_Fast t v) = "TPat_Fast (" ++ show t ++ ") (" ++ show v ++ ")"
+  show (TPat_Slow t v) = "TPat_Slow (" ++ show t ++ ") (" ++ show v ++ ")"
+  show (TPat_DegradeBy x r v) = "TPat_DegradeBy (" ++ show x ++ ") (" ++ show r ++ ") (" ++ show v ++ ")"
+  show (TPat_CycleChoose x vs) = "TPat_CycleChoose (" ++ show x ++ ") (" ++ show vs ++ ")"
+  show (TPat_Euclid a b c v) = "TPat_Euclid (" ++ show a ++ ") (" ++ show b ++ ") (" ++ show c ++ ") " ++ show v ++ ")"
+  show (TPat_Stack vs) = "TPat_Stack " ++ show vs
+  show (TPat_Polyrhythm mSteprate vs) = "TPat_Polyrhythm (" ++ show mSteprate ++ ") " ++ show vs
+  show (TPat_Seq vs) = "TPat_Seq " ++ show vs
+  show TPat_Silence = "TPat_Silence"
+  show TPat_Foot = "TPat_Foot"
+  show (TPat_Elongate r v) = "TPat_Elongate (" ++ show r ++ ") (" ++ show v ++ ")"
+  show (TPat_Repeat r v) = "TPat_Repeat (" ++ show r ++ ") (" ++ show v ++ ")"
+  show (TPat_EnumFromTo a b) = "TPat_EnumFromTo (" ++ show a ++ ") (" ++ show b ++ ")"
+  show (TPat_Var s) = "TPat_Var " ++ show s
+  show (TPat_Chord g iP nP msP) = "TPat_Chord (" ++ (show $ fmap g iP) ++ ") (" ++ show nP ++ ") (" ++ show msP ++ ")"
 
 instance Functor TPat where
   fmap f (TPat_Atom c v) = TPat_Atom c (f v)
@@ -129,6 +144,7 @@ tShow (TPat_Seq vs) = snd $ steps_seq vs
 tShow TPat_Silence = "silence"
 tShow (TPat_EnumFromTo a b) = "unwrap $ fromTo <$> (" ++ tShow a ++ ") <*> (" ++ tShow b ++ ")"
 tShow (TPat_Var s) = "getControl " ++ s
+tShow (TPat_Chord f n name mods) = "chord (" ++ (tShow $ fmap f n) ++ ") (" ++ tShow name ++ ") [" ++ (intercalate ", " $ map tShow mods) ++ "]"
 tShow a = "can't happen? " ++ show a
 
 

--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -144,7 +144,7 @@ tShow (TPat_Seq vs) = snd $ steps_seq vs
 tShow TPat_Silence = "silence"
 tShow (TPat_EnumFromTo a b) = "unwrap $ fromTo <$> (" ++ tShow a ++ ") <*> (" ++ tShow b ++ ")"
 tShow (TPat_Var s) = "getControl " ++ s
-tShow (TPat_Chord f n name mods) = "chord (" ++ (tShow $ fmap f n) ++ ") (" ++ tShow name ++ ") [" ++ (intercalate ", " $ map tShow mods) ++ "]"
+tShow (TPat_Chord f n name mods) = "chord (" ++ (tShow $ fmap f n) ++ ") (" ++ tShow name ++ ")" ++ tShowList mods
 tShow a = "can't happen? " ++ show a
 
 

--- a/test/Sound/Tidal/ParseTest.hs
+++ b/test/Sound/Tidal/ParseTest.hs
@@ -160,6 +160,42 @@ run =
         compareP (Arc 0 2)
           ("c'major c'minor" :: Pattern Note)
           ("'major 'minor")
+      it "can invert chords" $ do
+        compareP (Arc 0 2)
+          ("c'major'i" :: Pattern Note)
+          ("[4,7,12]")
+      it "can invert chords using a number" $ do
+        compareP (Arc 0 2)
+          ("c'major'i2" :: Pattern Note)
+          ("[7,12,16]")
+      it "spread chords over a range" $ do
+        compareP (Arc 0 2)
+          ("c'major'5 e'min7'5" :: Pattern Note)
+          ("[0,4,7,12,16] [4,7,11,14,16]")
+      it "can open chords" $ do
+        compareP (Arc 0 2)
+          ("c'major'o" :: Pattern Note)
+          ("[-12,-5,4]")
+      it "can drop notes in a chord" $ do
+        compareP (Arc 0 2)
+          ("c'major'd1" :: Pattern Note)
+          ("[-5,0,4]")
+      it "can apply multiple modifiers" $ do
+        compareP (Arc 0 2)
+          ("c'major'i'5" :: Pattern Note)
+          ("[4,7,12,16,19]")
+      it "can pattern modifiers" $ do
+        compareP (Arc 0 2)
+          ("c'major'<i 5>" :: Pattern Note)
+          ("<[4,7,12] [0,4,7,12,16]>")
+      it "can pattern chord names" $ do
+        compareP (Arc 0 2)
+          ("c'<major minor>'i" :: Pattern Note)
+          ("<[4,7,12] [3,7,12]>")
+      it "can pattern chord notes" $ do
+        compareP (Arc 0 2)
+          ("<c e>'<major minor>'i" :: Pattern Note)
+          ("<[4,7,12] [7,11,16]>")
       it "handle trailing and leading whitespaces" $ do
         compareP (Arc 0 1)
           ("  bd  " :: Pattern String)


### PR DESCRIPTION
to make this working, i had to change TPat to a generalised ADT to add a node for TPat_Chord that essentialy has three fields, one for each component of a chord: a `TPat a` where `a` is some Num type, a `TPat String` for chord names and a `[TPat [Modifier]]`  for modifiers. Due to some type trickery there is an additional field for making TPats instance of Functor (this is essentially the yoneda lemma applied, kind of like here https://stackoverflow.com/questions/17157579/functor-instance-for-a-gadt-with-type-constraint)

motivation for these changes was mainly this thread: https://club.tidalcycles.org/t/rfc-working-on-making-chord-naming-chordlist-more-consistent/2717/64

leaving the technical details behind, what these changes result in is a better seperation of syntax and semantics of chords, i.e., there is a corresponding semantic function `chord :: Num a => Pattern a -> Pattern String -> [Pattern [Modifier]] -> Pattern a`

further, every field in chords is patternable now and modifiers can be stacked
it should also be easy now to define new modifiers very quickly (like I did for the new drop modifier)

i also introduced two new functions `collect :: Pattern a -> Pattern [a]` and `uncollect :: Pattern [a] -> Pattern a` that collect/stack all events that have the exact same duration