### PR TITLE
avoid race in loading bootscript during restart

### DIFF
--- a/tidal.el
+++ b/tidal.el
@@ -107,8 +107,8 @@
        tidal-interpreter
        nil
        tidal-interpreter-arguments)
-      (tidal-see-output))
-    (tidal-send-string (concat ":script " tidal-boot-script-path)))
+      (tidal-see-output)
+      (tidal-send-string (concat ":script " tidal-boot-script-path))))
   (switch-to-buffer-other-window tidal-buffer))
 
 ;;;###autoload


### PR DESCRIPTION
In some cases BootTidal.hs could be loaded twice during the restart/start cycle. no longer.