### PR TITLE
Rename cCyclesPerBeat -> cBeatsPerCycle

### DIFF
--- a/src/Sound/Tidal/Config.hs
+++ b/src/Sound/Tidal/Config.hs
@@ -1,6 +1,5 @@
 module Sound.Tidal.Config where
 
-import qualified Sound.Tidal.Link as Link
 import Data.Int(Int64)
 import Foreign.C.Types (CDouble)
 

--- a/src/Sound/Tidal/Config.hs
+++ b/src/Sound/Tidal/Config.hs
@@ -35,7 +35,7 @@ data Config = Config {cCtrlListen :: Bool,
                       cSkipTicks :: Int64,
                       cVerbose :: Bool,
                       cQuantum :: CDouble,
-                      cCyclesPerBeat :: CDouble
+                      cBeatsPerCycle :: CDouble
                      }
 
 defaultConfig :: Config
@@ -52,5 +52,5 @@ defaultConfig = Config {cCtrlListen = True,
                         cSkipTicks = 10,
                         cVerbose = True,
                         cQuantum = 4,
-                        cCyclesPerBeat = 4
+                        cBeatsPerCycle = 4
                        }

--- a/src/Sound/Tidal/Safe/Context.hs
+++ b/src/Sound/Tidal/Safe/Context.hs
@@ -46,7 +46,7 @@ module Sound.Tidal.Safe.Context
   , streamSetB
   , transition
   , module C
-  , startTidal, superdirtTarget, Target(..)
+  , Target(..)
   )
 where
 
@@ -66,8 +66,7 @@ import Sound.Tidal.UI as C
 import Sound.Tidal.Version as C
 
 import qualified Sound.Tidal.Context as C
-import Sound.Tidal.Context
-  (Stream, Pattern, ControlPattern, Time)
+import Sound.Tidal.Context (Stream)
 import Control.Monad.Reader
 import Control.Monad.Catch
 
@@ -75,7 +74,7 @@ newtype Op r = Op ( ReaderT Stream IO r )
   deriving (Functor, Applicative, Monad, MonadCatch,MonadThrow)
 
 exec :: Stream -> Op r -> IO r
-exec s (Op m) = runReaderT m s
+exec stream (Op m) = runReaderT m stream
 
 op1 f         = Op $ do a <- ask; lift $ f a
 op2 f b       = Op $ do a <- ask; lift $ f a b 

--- a/src/Sound/Tidal/Stream.hs
+++ b/src/Sound/Tidal/Stream.hs
@@ -223,7 +223,7 @@ startStream config oscmap
                                                           ) (oAddress target) (oPort target)
                                         return $ Cx {cxUDP = u, cxAddr = remote_addr, cxBusAddr = remote_bus_addr, cxTarget = target, cxOSCs = os}                                        
                    ) oscmap
-       let bpm = (coerce defaultCps) * 60 * (cCyclesPerBeat config)
+       let bpm = (coerce defaultCps) * 60 * (cBeatsPerCycle config)
        abletonLink <- Link.create bpm
        let stream = Stream {sConfig = config,
                             sBusses = bussesMV,
@@ -746,7 +746,7 @@ streamGetcps s = do
   now <- Link.clock (sLink s)
   ss <- Link.createAndCaptureAppSessionState (sLink s)
   bpm <- Link.getTempo ss
-  return $! coerce $ bpm / (cCyclesPerBeat config) / 60
+  return $! coerce $ bpm / (cBeatsPerCycle config) / 60
 
 streamGetnow :: Stream -> IO Double
 streamGetnow s = do
@@ -754,4 +754,4 @@ streamGetnow s = do
   ss <- Link.createAndCaptureAppSessionState (sLink s)
   now <- Link.clock (sLink s)
   beat <- Link.beatAtTime ss now (cQuantum config)
-  return $! coerce $ beat / (cCyclesPerBeat config)
+  return $! coerce $ beat / (cBeatsPerCycle config)

--- a/src/Sound/Tidal/StreamTypes.hs
+++ b/src/Sound/Tidal/StreamTypes.hs
@@ -3,7 +3,6 @@ module Sound.Tidal.StreamTypes where
 import qualified Data.Map.Strict as Map
 import Sound.Tidal.Pattern
 import Sound.Tidal.Show ()
-import qualified Sound.Tidal.Link as Link
 
 data PlayState = PlayState {pattern :: ControlPattern,
                             mute :: Bool,

--- a/src/Sound/Tidal/Tempo.hs
+++ b/src/Sound/Tidal/Tempo.hs
@@ -88,11 +88,11 @@ setNudge actionsMV nudge = modifyMVar_ actionsMV (\actions -> return $ SetNudge 
 timeToCycles' :: Config -> Link.SessionState -> Link.Micros -> IO P.Time
 timeToCycles' config ss time = do
   beat <- Link.beatAtTime ss time (cQuantum config)
-  return $! (toRational beat) / (toRational (cCyclesPerBeat config))
+  return $! (toRational beat) / (toRational (cBeatsPerCycle config))
 
 cyclesToTime :: Config -> Link.SessionState -> P.Time -> IO Link.Micros
 cyclesToTime config ss cyc = do
-  let beat = (fromRational cyc) * (cCyclesPerBeat config)
+  let beat = (fromRational cyc) * (cBeatsPerCycle config)
   Link.timeAtBeat ss beat (cQuantum config)
 
 addMicrosToOsc :: Link.Micros -> O.Time -> O.Time
@@ -109,7 +109,7 @@ clocked config stateMV mapMV actionsMV ac abletonLink
         quantum :: CDouble
         quantum = cQuantum config
         cyclesPerBeat :: CDouble
-        cyclesPerBeat = cCyclesPerBeat config
+        cyclesPerBeat = cBeatsPerCycle config
         loopInit :: IO a
         loopInit =
           do

--- a/src/Sound/Tidal/Tempo.hs
+++ b/src/Sound/Tidal/Tempo.hs
@@ -108,8 +108,8 @@ clocked config stateMV mapMV actionsMV ac abletonLink
         frameTimespan = round $ (cFrameTimespan config) * 1000000
         quantum :: CDouble
         quantum = cQuantum config
-        cyclesPerBeat :: CDouble
-        cyclesPerBeat = cBeatsPerCycle config
+        beatsPerCycle :: CDouble
+        beatsPerCycle = cBeatsPerCycle config
         loopInit :: IO a
         loopInit =
           do
@@ -202,9 +202,9 @@ clocked config stateMV mapMV actionsMV ac abletonLink
             putMVar stateMV streamState'
             tick st'
         btc :: CDouble -> CDouble
-        btc beat = beat / cyclesPerBeat
+        btc beat = beat / beatsPerCycle
         ctb :: CDouble -> CDouble
-        ctb cyc =  cyc * cyclesPerBeat
+        ctb cyc =  cyc * beatsPerCycle
         processActions :: State -> [TempoAction] -> IO State
         processActions st [] = return $! st
         processActions st actions = do

--- a/src/Sound/Tidal/Tempo.hs
+++ b/src/Sound/Tidal/Tempo.hs
@@ -16,7 +16,6 @@ import Sound.Tidal.Config
 import Sound.Tidal.Utils (writeError)
 import qualified Sound.Tidal.Link as Link
 import Foreign.C.Types (CDouble(..))
-import Data.Coerce (coerce)
 import System.IO (hPutStrLn, stderr)
 import Data.Int(Int64)
 
@@ -64,7 +63,7 @@ data State = State {ticks    :: Int64,
 data ActionHandler =
   ActionHandler {
     onTick :: TickState -> LinkOperations -> P.ValueMap -> IO P.ValueMap,
-    onSingleTick :: Link.Micros -> LinkOperations -> P.ValueMap -> P.ControlPattern -> IO P.ValueMap,
+    onSingleTick :: LinkOperations -> P.ValueMap -> P.ControlPattern -> IO P.ValueMap,
     updatePattern :: ID -> P.ControlPattern -> IO ()
   }
 
@@ -252,7 +251,7 @@ clocked config stateMV mapMV actionsMV ac abletonLink
               beatToCycles = btc,
               cyclesToBeat = ctb
             }
-            streamState'' <- (onSingleTick ac) nowLink ops streamState' pat
+            streamState'' <- (onSingleTick ac) ops streamState' pat
             Link.commitAndDestroyAppSessionState abletonLink sessionState
             Link.destroySessionState zeroedSessionState
             return (st', streamState'')

--- a/src/Sound/Tidal/Transition.hs
+++ b/src/Sound/Tidal/Transition.hs
@@ -4,9 +4,8 @@ module Sound.Tidal.Transition where
 
 import Prelude hiding ((<*), (*>))
 
-import Control.Concurrent.MVar (readMVar, swapMVar, modifyMVar_)
+import Control.Concurrent.MVar (modifyMVar_)
 
-import qualified Sound.OSC.FD as O
 import qualified Data.Map.Strict as Map
 -- import Data.Maybe (fromJust)
 


### PR DESCRIPTION
There was a mixup during naming. Please help me double check that the calculations are correct now. Reference: https://tidalcycles.org/docs/patternlib/tutorials/cycles/#convert-between-bpm-and-cps