### PR TITLE
Use c++ extra library for MacOS

### DIFF
--- a/tidal-link/tidal-link.cabal
+++ b/tidal-link/tidal-link.cabal
@@ -50,7 +50,10 @@ library
   if impl(ghc >= 9.4)
     build-depends: system-cxx-std-lib
   else
-    extra-libraries: stdc++
+    if os(darwin)
+      extra-libraries: c++
+    else
+      extra-libraries: stdc++
 
   cxx-sources: link/extensions/abl_link/src/abl_link.cpp
   include-dirs:


### PR DESCRIPTION
libstdc++ is deprecated on MacOS. Until we switch to `system-cxx-std-lib`, it is necessary to use `libc++` for MacOS builds.