### PR TITLE
Add a Nix Flake for building and developing Tidal

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,42 @@
+# A set of CI jobs for checking the Nix flake.
+
+name: "nix"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  cancel-previous-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+  nix-fmt-check:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix fmt -- --check ./
+
+  nix-build:
+    needs: cancel-previous-runs
+    strategy:
+      matrix:
+        package: [tidal, tidal-link, tidal-listener, tidal-parse]
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ out/
 \#*\#
 .\#*
 
+# Allow flake.lock for reproducible builds
+!flake.lock
+# Ignore nix generated `result` symlink
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1667629849,
+        "narHash": "sha256-P+v+nDOFWicM4wziFK9S/ajF2lc0N2Rg9p6Y35uMoZI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3bacde6273b09a21a8ccfba15586fb165078fb62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,81 @@
+{
+  description = ''
+    A Nix flake for building and developing Tidal.
+
+    Packages are included for:
+    - tidal
+    - tidal-link
+    - tidal-listener
+    - tidal-parse
+
+    A `tidal-ghci` package is also included. This is a small script that starts
+    an instance of `GHCi` with `Tidal` installed and with the `BootTidal.hs`
+    file passed as the `-ghci-script`.
+
+    Packages can be built with `nix build .#tidal` or ran with `nix run
+    .#tidal-ghci`.
+
+    A `devShell` is included that provides `cabal-install`, `stack` and all
+    other build inputs for the tidal packages above included under a temporary
+    shell. This shell can be entered with `nix develop`.
+  '';
+
+  inputs = {
+    utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = inputs: let
+    utils.supportedSystems = [
+      "aarch64-linux"
+      "i686-linux"
+      "x86_64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+    utils.eachSupportedSystem =
+      inputs.utils.lib.eachSystem utils.supportedSystems;
+
+    mkPackages = pkgs: let
+      project = pkgs.haskellPackages.extend (pkgs.haskell.lib.compose.packageSourceOverrides {
+        tidal = ./.;
+        tidal-link = ./tidal-link;
+        tidal-listener = ./tidal-listener;
+        tidal-parse = ./tidal-parse;
+      });
+      tidal-boot = ./BootTidal.hs;
+      tidal-ghc = pkgs.haskellPackages.ghcWithPackages (hpkgs: [project.tidal]);
+    in {
+      tidal = project.tidal;
+      tidal-link = project.tidal-link;
+      tidal-listener = project.tidal-listener;
+      tidal-parse = project.tidal-parse;
+      tidal-ghci = pkgs.writeShellScriptBin "tidal-ghci" ''
+        ${tidal-ghc}/bin/ghci -ghci-script ${tidal-boot}
+      '';
+      default = inputs.self.packages.${pkgs.system}.tidal-ghci;
+    };
+
+    mkDevShells = pkgs: tidalpkgs: {
+      tidal = pkgs.mkShell {
+        inputsFrom = pkgs.lib.attrValues tidalpkgs;
+        buildInputs = [
+          pkgs.cabal-install
+          pkgs.stack
+        ];
+      };
+      default = inputs.self.devShells.${pkgs.system}.tidal;
+    };
+
+    mkOutput = system: let
+      pkgs = inputs.nixpkgs.legacyPackages.${system};
+    in {
+      packages = mkPackages pkgs;
+      devShells = mkDevShells pkgs inputs.self.packages.${system};
+      formatter = pkgs.alejandra;
+    };
+
+    systemOutputs = utils.eachSupportedSystem mkOutput;
+  in
+    systemOutputs;
+}


### PR DESCRIPTION
Hi folks! I've been digging into the Tidal code-base lately and thought I'd share the Nix flake I've been using to setup my Tidal environment and enable reproducible builds.

The following is from the flake's description:

> This adds a Nix flake for building and developing Tidal.
> 
> Packages are included for:
> - tidal
> - tidal-link
> - tidal-listener
> - tidal-parse
> 
> A `tidal-ghci` package is also included. This is a small script that starts an instance of `GHCi` with `Tidal` installed and with the `BootTidal.hs` file passed as the `-ghci-script`.
> 
> Packages can be built with `nix build .#tidal` or ran with `nix run .#tidal-ghci`.
> 
> A `devShell` is included that provides `cabal-install`, `stack` and all other build inputs for the tidal packages above included under a temporary shell. This shell can be entered with `nix develop`.

Note that [flakes](https://nixos.wiki/wiki/Flakes) are still an experimental feature of Nix! Their UX is such an improvement on the old workflow that I use them exclusively these days.

That said, I'd understand if the preference was to wait until the feature stabilizes in Nix before landing something like this.

Fwiw, I plan to keep using Tidal for the foreseeable future and am happy to help maintain this going forward (I'm also helping maintain [vim-tidal](https://github.com/tidalcycles/vim-tidal/graphs/contributors)).

A workflow has also been added that checks the formatting of the Nix code and checks that each of the packages build on x86 Linux and macOS.