### PR TITLE
`trigger` and friends without pattern IDs

### DIFF
--- a/src/Sound/Tidal/Control.hs
+++ b/src/Sound/Tidal/Control.hs
@@ -29,6 +29,7 @@ import Data.Ratio
 
 import Sound.Tidal.Pattern
 import Sound.Tidal.Core
+import Sound.Tidal.Stream (patternTimeID)
 import Sound.Tidal.UI
 import qualified Sound.Tidal.Params as P
 import Sound.Tidal.Utils
@@ -472,8 +473,8 @@ mt = mtrigger
 triggerWith :: (Time -> Time) -> Pattern a -> Pattern a
 triggerWith f pat = pat {query = q}
   where q st = query (rotR (offset st) pat) st
-        offset st = fromMaybe 0 $ f <$> (Map.lookup ctrl (controls st) >>= getR)
-        ctrl = "_t_pattern"
+        offset st = fromMaybe 0 $ f
+                      <$> (Map.lookup patternTimeID (controls st) >>= getR)
 
 splat :: Pattern Int -> ControlPattern -> ControlPattern -> ControlPattern
 splat slices epat pat = chop slices pat # bite 1 (const 0 <$> pat) epat

--- a/src/Sound/Tidal/Control.hs
+++ b/src/Sound/Tidal/Control.hs
@@ -412,29 +412,28 @@ sec p = (realToFrac <$> cF 1 "_cps") *| p
 msec :: Fractional a => Pattern a -> Pattern a
 msec p = (realToFrac . (/1000) <$> cF 1 "_cps") *| p
 
-triggerWith :: Show a => (Time -> Time) -> a -> Pattern b -> Pattern b
-triggerWith f k pat = pat {query = q}
+triggerWith :: (Time -> Time) -> Pattern a -> Pattern a
+triggerWith f pat = pat {query = q}
   where q st = query (rotR (offset st) pat) st
-        offset st = fromMaybe 0 $ do v <- Map.lookup ctrl (controls st)
-                                     return (f $ fromMaybe 0 $ getR v)
-        ctrl = "_t_" ++ show k
+        offset st = fromMaybe 0 $ f <$> (Map.lookup ctrl (controls st) >>= getR)
+        ctrl = "_t_pattern"
 
-trigger :: Show a => a -> Pattern b -> Pattern b
+trigger :: Pattern a -> Pattern a
 trigger = triggerWith id
 
-ctrigger :: Show a => a -> Pattern b -> Pattern b
+ctrigger :: Pattern a -> Pattern a
 ctrigger = triggerWith $ (fromIntegral :: Int -> Rational) . ceiling
 
-qtrigger :: Show a => a -> Pattern b -> Pattern b
+qtrigger :: Pattern a -> Pattern a
 qtrigger = ctrigger
 
-rtrigger :: Show a => a -> Pattern b -> Pattern b
+rtrigger :: Pattern a -> Pattern a
 rtrigger = triggerWith $ (fromIntegral :: Int -> Rational) . round
 
-ftrigger :: Show a => a -> Pattern b -> Pattern b
+ftrigger :: Pattern a -> Pattern a
 ftrigger = triggerWith $ (fromIntegral :: Int -> Rational) . floor
 
-qt :: Show a => a -> Pattern b -> Pattern b
+qt :: Pattern a -> Pattern a
 qt = qtrigger
 
 reset :: Show a => a -> Pattern b -> Pattern b

--- a/src/Sound/Tidal/Control.hs
+++ b/src/Sound/Tidal/Control.hs
@@ -421,11 +421,14 @@ triggerWith f pat = pat {query = q}
 trigger :: Pattern a -> Pattern a
 trigger = triggerWith id
 
-ctrigger :: Pattern a -> Pattern a
-ctrigger = triggerWith $ (fromIntegral :: Int -> Rational) . ceiling
-
 qtrigger :: Pattern a -> Pattern a
 qtrigger = ctrigger
+
+qt :: Pattern a -> Pattern a
+qt = qtrigger
+
+ctrigger :: Pattern a -> Pattern a
+ctrigger = triggerWith $ (fromIntegral :: Int -> Rational) . ceiling
 
 rtrigger :: Pattern a -> Pattern a
 rtrigger = triggerWith $ (fromIntegral :: Int -> Rational) . round
@@ -433,16 +436,12 @@ rtrigger = triggerWith $ (fromIntegral :: Int -> Rational) . round
 ftrigger :: Pattern a -> Pattern a
 ftrigger = triggerWith $ (fromIntegral :: Int -> Rational) . floor
 
-qt :: Pattern a -> Pattern a
-qt = qtrigger
+mtrigger :: Int -> Pattern a -> Pattern a
+mtrigger n = triggerWith $ fromIntegral . nextMod
+  where nextMod t = n * ceiling (t / (fromIntegral n))
 
-reset :: Show a => a -> Pattern b -> Pattern b
-reset k pat = pat {query = q}
-  where q st = query (rotR (offset st) $ when (<=0) (const silence) pat) st
-        f = (fromIntegral :: Int -> Rational) . floor
-        offset st = fromMaybe 0 $ do p <- Map.lookup ctrl (controls st)
-                                     return (f $ fromMaybe 0 $ getR p)
-        ctrl = "_t_" ++ show k
+mt :: Pattern a -> Pattern a
+mt = mtrigger
 
 splat :: Pattern Int -> ControlPattern -> ControlPattern -> ControlPattern
 splat slices epat pat = chop slices pat # bite 1 (const 0 <$> pat) epat

--- a/src/Sound/Tidal/Pattern.hs
+++ b/src/Sound/Tidal/Pattern.hs
@@ -378,6 +378,10 @@ withQueryArc f pat = pat {query = query pat . (\(State a m) -> State (f a) m)}
 withQueryTime :: (Time -> Time) -> Pattern a -> Pattern a
 withQueryTime f pat = withQueryArc (\(Arc s e) -> Arc (f s) (f e)) pat
 
+-- | Apply a function to the control values of the query
+withQueryControls :: (ValueMap -> ValueMap) -> Pattern a -> Pattern a
+withQueryControls f pat = pat { query = query pat . (\(State a m) -> State a (f m))}
+
 -- | @withEvent f p@ returns a new @Pattern@ with each event mapped over
 -- function @f@.
 withEvent :: (Event a -> Event b) -> Pattern a -> Pattern b

--- a/src/Sound/Tidal/Stream.hs
+++ b/src/Sound/Tidal/Stream.hs
@@ -332,11 +332,10 @@ getString cm s = (simpleShow <$> Map.lookup param cm) <|> defaultValue dflt
                             defaultValue _ = Nothing
 
 playStack :: PlayMap -> ControlPattern
-playStack pMap = stack $ map pattern active
-  where active = filter (\pState -> if hasSolo pMap
-                                    then solo pState
-                                    else not (mute pState)
-                        ) $ Map.elems pMap
+playStack pMap = stack . (map pattern) . (filter active) . Map.elems $ pMap
+  where active pState = if hasSolo pMap
+                        then solo pState
+                        else not (mute pState)
 
 toOSC :: [Int] -> ProcessedEvent -> OSC -> [(Double, Bool, O.Message)]
 toOSC busses pe osc@(OSC _ _)
@@ -401,15 +400,17 @@ toOSC _ pe (OSCContext oscpath)
         ts = (peOnWholeOrPartOsc pe) + nudge -- + latency
 
 -- Used for Tempo callback
-updatePattern :: Stream -> ID -> ControlPattern -> IO ()
-updatePattern stream k pat = do
+updatePattern :: Stream -> ID -> Time -> ControlPattern -> IO ()
+updatePattern stream k !t pat = do
   let x = queryArc pat (Arc 0 0)
   pMap <- seq x $ takeMVar (sPMapMV stream)
   let playState = updatePS $ Map.lookup (fromID k) pMap
   putMVar (sPMapMV stream) $ Map.insert (fromID k) playState pMap
   where updatePS (Just playState) = do playState {pattern = pat', history = pat:(history playState)}
         updatePS Nothing = PlayState pat' False False [pat']
-        pat' = pat # pS "_id_" (pure $ fromID k)
+        patControls = Map.singleton "_t_pattern" (VR t)
+        pat' = withQueryControls (Map.union patControls)
+                 $ pat # pS "_id_" (pure $ fromID k)
 
 processCps :: T.LinkOperations -> [Event ValueMap] -> IO [ProcessedEvent]
 processCps ops = mapM processEvent

--- a/src/Sound/Tidal/Stream.hs
+++ b/src/Sound/Tidal/Stream.hs
@@ -399,6 +399,9 @@ toOSC _ pe (OSCContext oscpath)
         ident = fromMaybe "unknown" $ Map.lookup "_id_" (value $ peEvent pe) >>= getS
         ts = (peOnWholeOrPartOsc pe) + nudge -- + latency
 
+patternTimeID :: String
+patternTimeID = "_t_pattern"
+
 -- Used for Tempo callback
 updatePattern :: Stream -> ID -> Time -> ControlPattern -> IO ()
 updatePattern stream k !t pat = do
@@ -408,7 +411,7 @@ updatePattern stream k !t pat = do
   putMVar (sPMapMV stream) $ Map.insert (fromID k) playState pMap
   where updatePS (Just playState) = do playState {pattern = pat', history = pat:(history playState)}
         updatePS Nothing = PlayState pat' False False [pat']
-        patControls = Map.singleton "_t_pattern" (VR t)
+        patControls = Map.singleton patternTimeID (VR t)
         pat' = withQueryControls (Map.union patControls)
                  $ pat # pS "_id_" (pure $ fromID k)
 

--- a/src/Sound/Tidal/Tempo.hs
+++ b/src/Sound/Tidal/Tempo.hs
@@ -62,7 +62,7 @@ data ActionHandler =
   ActionHandler {
     onTick :: TickState -> LinkOperations -> P.ValueMap -> IO P.ValueMap,
     onSingleTick :: LinkOperations -> P.ValueMap -> P.ControlPattern -> IO P.ValueMap,
-    updatePattern :: ID -> P.ControlPattern -> IO ()
+    updatePattern :: ID -> P.Time -> P.ControlPattern -> IO ()
   }
 
 data LinkOperations =
@@ -272,7 +272,7 @@ clocked config stateMV mapMV actionsMV ac abletonLink
                 Link.destroySessionState sessionState
                 -- put pattern id and change time in control input
                 let streamState'' = Map.insert ("_t_all") (P.VR $! cyc) $ Map.insert ("_t_" ++ fromID k) (P.VR $! cyc) streamState'
-                (updatePattern ac) k pat
+                (updatePattern ac) k cyc pat
                 return (st', streamState'')
               )
               (\(e :: E.SomeException) -> do

--- a/src/Sound/Tidal/Tempo.hs
+++ b/src/Sound/Tidal/Tempo.hs
@@ -270,10 +270,8 @@ clocked config stateMV mapMV actionsMV ac abletonLink
                 sessionState <- Link.createAndCaptureAppSessionState abletonLink
                 cyc <- timeToCycles' config sessionState now
                 Link.destroySessionState sessionState
-                -- put pattern id and change time in control input
-                let streamState'' = Map.insert ("_t_all") (P.VR $! cyc) $ Map.insert ("_t_" ++ fromID k) (P.VR $! cyc) streamState'
                 (updatePattern ac) k cyc pat
-                return (st', streamState'')
+                return (st', streamState')
               )
               (\(e :: E.SomeException) -> do
                 hPutStrLn stderr $ "Error in pattern: " ++ show e

--- a/tidal-parse/src/Sound/Tidal/Parse.hs
+++ b/tidal-parse/src/Sound/Tidal/Parse.hs
@@ -295,6 +295,7 @@ genericTransformations =
     $(fromTidal "loopFirst") <|>
     $(fromTidal "degrade") <|>
     $(fromTidal "arpeggiate") <|>
+    $(fromTidal "trigger") <|>
     constParser <*!> parser <|>
     -- more complex possibilities that would involve overlapped Parse instances if they were instances
     pTime_p_p <*!> parser <|>
@@ -310,12 +311,6 @@ genericTransformations =
     (parser :: H ([Pattern Time] -> Pattern a -> Pattern a)) <*!> parser <|>
     (parser :: H ([Pattern Double] -> Pattern a -> Pattern a)) <*!> parser <|>
     (parser :: H ([Pattern a -> Pattern a] -> Pattern a -> Pattern a)) <*!> parser <|>
-    int_p_p <*!> parser <|>
-    integer_p_p <*!> parser <|>
-    double_p_p <*!> parser <|>
-    time_p_p <*!> parser <|>
-    string_p_p <*!> parser <|>
-    bool_p_p <*!> parser <|>
     lp_p_p <*!> parser <|>
     a_patternB <|>
     pA_pB
@@ -641,28 +636,6 @@ instance Parse ((Time,Time) -> Pattern a -> Pattern a) where
 
 pString_pInt_pString :: H (Pattern String -> Pattern Int -> Pattern String)
 pString_pInt_pString = $(fromTidal "samples")
-
-showable_p_p :: (Show a, Parse a) => H (a -> Pattern b -> Pattern b)
-showable_p_p = $(fromTidal "trigger")
--- *** pathway leading to spread(etc) should be incorporated here also???
-
-int_p_p :: H (Int -> Pattern a -> Pattern a)
-int_p_p = showable_p_p
-
-integer_p_p :: H (Integer -> Pattern a -> Pattern a)
-integer_p_p = showable_p_p
-
-time_p_p :: H (Time -> Pattern a -> Pattern a)
-time_p_p = showable_p_p
-
-double_p_p :: H (Double -> Pattern a -> Pattern a)
-double_p_p = showable_p_p
-
-string_p_p :: H (String -> Pattern a -> Pattern a)
-string_p_p = showable_p_p
-
-bool_p_p :: H (Bool -> Pattern a -> Pattern a)
-bool_p_p = showable_p_p
 
 pTime_p_p :: H (Pattern Time -> Pattern a -> Pattern a)
 pTime_p_p =


### PR DESCRIPTION
Looking into the `trigger` family of functions, I wanted to see how easily it would be to get rid of the redundancy of having to specify the pattern ID, which I've found confusing before. Since Alex [seems open to getting rid of it](https://club.tidalcycles.org/t/how-to-trigger-a-pattern-reliably-from-the-start/3058/18), I went ahead and wrote up a change that would do just that.

This introduces a new set of controls that would be stored per-pattern and then merged into the rest of the query controls when the patterns are queried. I could see this mechanism eventually including the pattern ID itself, mute/solo state, as well as other information supplied by the editor (for example, code line number(s) and so on). In theory, the pattern history could also be passed in as a per-pattern control, allowing for transitions to be implemented as patterns themselves.

For now, I wanted to see what you all (@yaxu and maybe @Zalastax and anyone else with an opinion) thought about this approach. There are still a few open questions that I have:

- `patControls` should probably be saved in history and reverted when a pattern is reverted. That's different from (but I think an improvement over) the current behavior.
- I need to also fix `reset`, but I haven't touched it yet, because I don't really understand it. As far as I can tell, `reset` is equivalent to `ftrigger $ filterWhen (>= 0)`, but `ftrigger` always places the 0 point slightly before the pattern is started, so the filter has no effect (except, I guess, if the user calls `resetCycles`). I can't find much documentation&mdash;is this function worth keeping?
- I left in the old behavior where all patterns can look up an arbitrary pattern's start time with `cf0 "_t_1"`, `cf0 "_t_2"`, etc. Is that ever useful? Is it useful to have the ability to trigger a pattern based on when a different pattern was first evaluated?
- Passing in the evaluation time as a per-pattern control theoretically means that `trigger` could also play nice with `once`/`first`, but I don't know enough about how `once`/`first` are supposed to work to understand how they'd work with `trigger`.
- `trigger` has the same problem that `resetCycles` used to have where events happening immediately at the start of the trigger get skipped by the next pattern query. That's a problem with the existing behavior as well, and should probably be a separate bug.
- Really minor, but `trigger` and friends shouldn't be in `Control.hs`, since they're not specific to control patterns. Where should they be?

This fixes #968, albeit by changing function signatures and thereby introducing a breaking change. I'm open to suggestions as to when would be a good time to merge/release this. Thanks so much!