### PR TITLE
Comments on time, and haddock fixes

### DIFF
--- a/src/Sound/Tidal/Time.hs
+++ b/src/Sound/Tidal/Time.hs
@@ -38,16 +38,16 @@ instance (Fractional a) => Fractional (ArcF a) where
 
 -- Utility functions - Time
 
--- | The 'sam' (start of cycle) for the given time value.
+-- | The @sam@ (start of cycle) for the given time value.
 -- Cycles have duration 1, so every integer Time value divides two cycles.
 sam :: Time -> Time
 sam = fromIntegral . (floor :: Time -> Int)
 
--- | Turns a number into a (rational) time value. An alias for 'toRational'.
+-- | Turns a number into a (rational) time value. An alias for @toRational@.
 toTime :: Real a => a -> Rational
 toTime = toRational
 
--- | Turns a (rational) time value into another number. An alias for 'fromRational'.
+-- | Turns a (rational) time value into another number. An alias for @fromRational@.
 fromTime :: Fractional a => Time -> a
 fromTime = fromRational
 
@@ -102,15 +102,15 @@ timeToCycleArc t = Arc (sam t) (sam t + 1)
 cycleArc :: Arc -> Arc
 cycleArc (Arc s e) = Arc (cyclePos s) (cyclePos s + (e-s))
 
--- | Returns the numbers of the cycles that the input Arc overlaps
--- (excluding the input Arc's endpoint, unless it has duration 0 --
+-- | Returns the numbers of the cycles that the input @Arc@ overlaps
+-- (excluding the input @Arc@'s endpoint, unless it has duration 0 --
 -- see "Edge cases" below).
--- The "cycle number" of an Arc is equal to its start value.
--- Thus, for instance, `cyclesInArc (Arc 0 1.5) == [0,1]`.
--- * Edge cases:
---     `cyclesInArc $ Arc 0 1.0001 == [0,1]`
---     `cyclesInArc $ Arc 0 1      == [0]` -- the endpoint is excluded
---     `cyclesInArc $ Arc 1 1      == [1]` -- unless the Arc has duration 0
+-- The "cycle number" of an @Arc@ is equal to its start value.
+-- Thus, for instance, @cyclesInArc (Arc 0 1.5) == [0,1]@.
+-- Edge cases:
+-- >  cyclesInArc $ Arc 0 1.0001 == [0,1]
+-- >  cyclesInArc $ Arc 0 1      == [0] -- the endpoint is excluded
+-- >  cyclesInArc $ Arc 1 1      == [1] -- unless the Arc has duration 0
 cyclesInArc :: Integral a => Arc -> [a]
 cyclesInArc (Arc s e)
   | s > e = []
@@ -124,7 +124,7 @@ cyclesInArc (Arc s e)
 cycleArcsInArc :: Arc -> [Arc]
 cycleArcsInArc = map (timeToCycleArc . (toTime :: Int -> Time)) . cyclesInArc
 
--- | Splits the given 'Arc' into a list of 'Arc's, at cycle boundaries.
+-- | Splits the given @Arc@ into a list of @Arc@s, at cycle boundaries.
 arcCycles :: Arc -> [Arc]
 arcCycles (Arc s e) | s >= e = []
                 | sam s == sam e = [Arc s e]
@@ -135,7 +135,7 @@ arcCyclesZW :: Arc -> [Arc]
 arcCyclesZW (Arc s e) | s == e = [Arc s e]
                   | otherwise = arcCycles (Arc s e)
 
--- | Similar to 'fmap' but time is relative to the cycle (i.e. the
+-- | Similar to @fmap@ but time is relative to the cycle (i.e. the
 -- sam of the start of the arc)
 mapCycle :: (Time -> Time) -> Arc -> Arc
 mapCycle f (Arc s e) = Arc (sam' + f (s - sam')) (sam' + f (e - sam'))

--- a/src/Sound/Tidal/Time.hs
+++ b/src/Sound/Tidal/Time.hs
@@ -105,22 +105,29 @@ cycleArc (Arc s e) = Arc (cyclePos s) (cyclePos s + (e-s))
 -- | Returns the numbers of the cycles that the input @Arc@ overlaps
 -- (excluding the input @Arc@'s endpoint, unless it has duration 0 --
 -- see "Edge cases" below).
--- The "cycle number" of an @Arc@ is equal to its start value.
--- Thus, for instance, @cyclesInArc (Arc 0 1.5) == [0,1]@.
+-- (The "cycle number" of an @Arc@ is equal to its start value.
+-- Thus, for instance, @cyclesInArc (Arc 0 1.5) == [0,1]@.)
+--
 -- Edge cases:
 -- >  cyclesInArc $ Arc 0 1.0001 == [0,1]
 -- >  cyclesInArc $ Arc 0 1      == [0] -- the endpoint is excluded
 -- >  cyclesInArc $ Arc 1 1      == [1] -- unless the Arc has duration 0
+--
+-- PITFALL: Don't be fooled by the name. The output cycles
+-- are not necessarily completely contained in the input @Arc@,
+-- but they definitely overlap it,
+-- and they include every cycle that overlaps it.
 cyclesInArc :: Integral a => Arc -> [a]
 cyclesInArc (Arc s e)
   | s > e = []
   | s == e = [floor s]
   | otherwise = [floor s .. ceiling e-1]
 
--- | The whole cycles that overlap the input Arc,
--- (excluding its endpoint, unless it has duration 0,
--- similarly to `cyclesInArc` --
--- see that function's description for details).
+-- | This provides exactly the same information as @cyclesInArc@,
+-- except that this represents its output as @Arc@s,
+-- whereas @cyclesInArc@ represents the same information as integral indices.
+-- (The @Arc@ from 0 to 1 corresponds to the index 0,
+-- the one from 1 to 2 has index 1, etc.)
 cycleArcsInArc :: Arc -> [Arc]
 cycleArcsInArc = map (timeToCycleArc . (toTime :: Int -> Time)) . cyclesInArc
 


### PR DESCRIPTION
The first of these commits, 824719f34b70536f, fixes some Haddock syntax that I wrote the wrong way a long time ago.

The second, 5d6c8cb99c82d3df, adds or updates comments for these time-related functions:
```
      <*> -- for Patterns
      <*  -- the one in Sound.Tidal.Patterns
      *>  -- the one in Sound.Tidal.Patterns
      cyclesInArc
      cycleArcsInArc
```