### PR TITLE
Remove tidal-parse from stack build to match cabal.project.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,6 @@ resolver: lts-20.5
 
 packages:
   - '.'
-  - 'tidal-parse'
   - 'tidal-link'
 
 extra-deps:


### PR DESCRIPTION
`stack build` is broken on a new checkout because it attempts to build tidal-parse.