### PR TITLE
add metatune param

### DIFF
--- a/bin/generate-params.hs
+++ b/bin/generate-params.hs
@@ -178,6 +178,7 @@ genericParams = [
   ("f", "loop", "loops the sample (from `begin` to `end`) the specified number of times."),
   ("f", "lophat", ""),
   ("f", "lsnare", ""),
+  ("f", "metatune", "A pattern of numbers. Specifies whether the pitch of played samples should be tuned relative to their pitch metadata, if it exists. When set to 1, pitch metadata is applied. When set to 0, pitch metadata is ignored."),
   ("note", "n", "The note or sample number to choose for a synth or sampleset"),
   ("note", "note", "The note or pitch to play a sound or synth with"),
   ("f", "degree", ""),

--- a/src/Sound/Tidal/Params.hs
+++ b/src/Sound/Tidal/Params.hs
@@ -1609,6 +1609,21 @@ lsnarebus busid pat = pF "lsnare" pat # pI "^lsnare" busid
 lsnarerecv :: Pattern p => p Int -> p ValueMap
 lsnarerecv busid = pI "^lsnare" busid
 
+-- | A pattern of numbers. Specifies whether the pitch of played samples should be tuned relative to their pitch metadata, if it exists. When set to 1, pitch metadata is applied. When set to 0, pitch metadata is ignored.
+metatune :: Pattern p => p Double -> p ValueMap
+metatune = pF "metatune"
+metatuneTake :: Pattern p => String -> [Double] -> p ValueMap
+metatuneTake name xs = pStateListF "metatune" name xs
+metatuneCount :: Pattern p => String -> p ValueMap
+metatuneCount name = pStateF "metatune" name (maybe 0 (+1))
+metatuneCountTo :: Pattern p => String -> p Double -> p ValueMap
+metatuneCountTo name ipat = innerJoin $ (\i -> pStateF "metatune" name (maybe 0 ((`mod'` i) . (+1)))) <$> ipat
+
+metatunebus :: Pattern p => p Int -> p Double -> p ValueMap
+metatunebus busid pat = pF "metatune" pat # pI "^metatune" busid
+metatunerecv :: Pattern p => p Int -> p ValueMap
+metatunerecv busid = pI "^metatune" busid
+
 -- |
 midibend :: Pattern p => p Double -> p ValueMap
 midibend = pF "midibend"


### PR DESCRIPTION
adds support for the [`metatune` functionality](https://github.com/musikinformatik/SuperDirt/issues/273) recently merged into SuperDirt.

to summarize:

- WAV files can contain pitch metadata in a `smpl` chunk, commonly used by samplers for automatic pitch mapping
- SuperDirt now reads and stores this metadata for each loaded sample
- when the `dirt_sample` synth is passed `metatune = 1`, it tunes sample playback relative to the sample's pitch metadata

so given e.g. an instrument sample `foo:2` recorded at F#4 and tagged as such in its metadata, it is now possible to do `d1 $ note "c3" # s "foo:2" # metatune 1` and it will actually play at C3!

`metatune` defaults to `0`, in which case C4 is used as the reference pitch, just like before. C4 is also the fallback when `metatune = 1` but the specified sample lacks pitch metadata.