### PR TITLE
Build fixes for Tidal 1.9

### DIFF
--- a/.github/workflows/listener-build-windows.yml
+++ b/.github/workflows/listener-build-windows.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Haskell
-        uses: haskell/actions/setup@v1
+        uses: haskell/actions/setup@v2
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0
-      - uses: cachix/install-nix-action@v16
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - run: nix fmt -- --check ./
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2.4.0
-      - uses: cachix/install-nix-action@v16
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,29 @@
 {
   "nodes": {
+    "hosc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669944828,
+        "narHash": "sha256-cHEf0yEiwNnEpDj7SSQWRMUEAT5USHuuUCPuzOXHWrk=",
+        "owner": "rd--",
+        "repo": "hosc",
+        "rev": "e77aa67cd0b99a32498fef246a687ba443c9b4be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rd--",
+        "repo": "hosc",
+        "rev": "e77aa67cd0b99a32498fef246a687ba443c9b4be",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667629849,
-        "narHash": "sha256-P+v+nDOFWicM4wziFK9S/ajF2lc0N2Rg9p6Y35uMoZI=",
+        "lastModified": 1687807295,
+        "narHash": "sha256-7TUD0p0m4mZpIi1O+Cyk5NCqpJUnhv/CJOAuHOndjao=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3bacde6273b09a21a8ccfba15586fb165078fb62",
+        "rev": "6b3d1b1cf13f407fef5e634b224d575eb7211975",
         "type": "github"
       },
       "original": {
@@ -18,17 +35,36 @@
     },
     "root": {
       "inputs": {
+        "hosc": "hosc",
         "nixpkgs": "nixpkgs",
         "utils": "utils"
       }
     },
-    "utils": {
+    "systems": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,14 @@
   inputs = {
     utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    # Temporarily add `hosc` at the latest v0.20 commit
+    # (nixpkgs currently only has 0.19.1).
+    # See this comment for details:
+    # https://github.com/tidalcycles/Tidal/pull/1022#issuecomment-1610978403
+    hosc = {
+      url = "github:rd--/hosc?rev=e77aa67cd0b99a32498fef246a687ba443c9b4be";
+      flake = false;
+    };
   };
 
   outputs = inputs: let
@@ -38,6 +46,7 @@
 
     mkPackages = pkgs: let
       project = pkgs.haskellPackages.extend (pkgs.haskell.lib.compose.packageSourceOverrides {
+        hosc = inputs.hosc; # Remove once `hosc` is at 0.20 in nixpkgs.
         tidal = ./.;
         tidal-link = ./tidal-link;
         tidal-listener = ./tidal-listener;

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ resolver: lts-20.5
 packages:
   - '.'
   - 'tidal-parse'
+  - 'tidal-listener'
   - 'tidal-link'
 
 extra-deps:

--- a/tidal-listener/tidal-listener.cabal
+++ b/tidal-listener/tidal-listener.cabal
@@ -33,7 +33,7 @@ library
   default-language:    Haskell2010
   ghc-options: -threaded
                -Wall
-               -dynamic
+               -dynamic-too
                -- see: https://github.com/haskell-hint/hint/issues/156
 
 

--- a/tidal-listener/tidal-listener.cabal
+++ b/tidal-listener/tidal-listener.cabal
@@ -33,8 +33,9 @@ library
   default-language:    Haskell2010
   ghc-options: -threaded
                -Wall
-               -dynamic-too
                -- see: https://github.com/haskell-hint/hint/issues/156
+  if !os(windows)
+    ghc-options:           -dynamic-too
 
 
 executable tidal-listener
@@ -46,5 +47,6 @@ executable tidal-listener
   default-language:    Haskell2010
   ghc-options: -threaded
                -Wall
-               -dynamic
                -- see: https://github.com/haskell-hint/hint/issues/156
+  if !os(windows)
+    ghc-options:           -dynamic-too


### PR DESCRIPTION
The current 1.9 branch has some of the same build issues that were resolved for 2.0 by #1020 and #1022. Some of the 2.0 issues aren't applicable here (e.g. `tidal-parse` not building because it hadn't been updated for 2.0), so I'm going to move patches over individually until the build stops failing.