### PR TITLE
More build fixes

### DIFF
--- a/.github/workflows/listener-build-linux.yml
+++ b/.github/workflows/listener-build-linux.yml
@@ -1,6 +1,11 @@
 name: build-listener-linux
-
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
 
 jobs:
   build:

--- a/.github/workflows/listener-build-macosx.yml
+++ b/.github/workflows/listener-build-macosx.yml
@@ -1,6 +1,11 @@
 name: build-listener-macosx
-
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
 
 jobs:
   build:

--- a/.github/workflows/listener-build-windows.yml
+++ b/.github/workflows/listener-build-windows.yml
@@ -1,6 +1,11 @@
 name: build-listener-windows
-
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
 
 jobs:
   build:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,12 +1,13 @@
 # A set of CI jobs for checking the Nix flake.
 
 name: "nix"
-
 on:
-  pull_request:
   push:
-    branches:
-      - master
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
 
 jobs:
   cancel-previous-runs:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -32,7 +32,7 @@ jobs:
     needs: cancel-previous-runs
     strategy:
       matrix:
-        package: [tidal, tidal-link, tidal-listener, tidal-parse]
+        package: [tidal, tidal-link, tidal-parse]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.5
+resolver: lts-22.8
 
 packages:
   - '.'
@@ -8,6 +8,6 @@ packages:
 
 extra-deps:
   - hosc-0.20
-  - haskellish-0.3.2.1
+  - haskellish-0.3.2.2
 
 

--- a/tidal-parse/tidal-parse.cabal
+++ b/tidal-parse/tidal-parse.cabal
@@ -35,7 +35,7 @@ library
     , template-haskell
     , haskellish >= 0.3.2 && < 0.4
     , containers < 0.7
-    , mtl >= 2.2.2 && <2.3
+    , mtl >= 2.2.2 && <2.4
     , text < 2.1
 
   if !impl(ghc >= 8.4.1)


### PR DESCRIPTION
Unify conditions under which various build actions occur, and disable Nix build of tidal-listener because there's not a clear path forward there and the listener has always been experimental (see #1054).