### PR TITLE
Fix negative numbers not working for boolean euclids 

### DIFF
--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -854,7 +854,8 @@ euclidFull n k pa pb = stack [ euclid n k pa, euclidInv n k pb ]
 
 -- | Less expressive than 'euclid' due to its constrained types, but may be more efficient.
 _euclidBool :: Int -> Int -> Pattern Bool -- TODO: add 'euclidBool'?
-_euclidBool n k = fastFromList $ bjorklund (n,k)
+_euclidBool n k | n >= 0 = fastFromList $ bjorklund (n,k)
+                | otherwise = fastFromList $ fmap (not) $ bjorklund (-n,k)
 
 _euclid' :: Int -> Int -> Pattern a -> Pattern a
 _euclid' n k p = fastcat $ map (\x -> if x then p else silence) (bjorklund (n,k))


### PR DESCRIPTION
As you may remember, with #915 and #916, we added the possibility of using negative values for the first argument of euclidian rhythms. However we forgot to replicate this behaviour for boolean euclidian patterns.

This fixes the following bug I've encountered:

```haskell
-- works
d1 $ mask "t(5,16)" $ s "808lt*16" |- note (saw*2) # shape 0.3 # octave 6

-- goes silent:
d1 $ mask "t(-5,16)" $ s "808lt*16" |- note (saw*2) # shape 0.3 # octave 6
```