### PR TITLE
Add `getbpm` and `setbpm` to boot functions

### DIFF
--- a/src/Sound/Tidal/Boot.hs
+++ b/src/Sound/Tidal/Boot.hs
@@ -27,6 +27,8 @@ module Sound.Tidal.Boot
   , setCycle
   , setcps
   , getcps
+  , setbpm
+  , getbpm
   , getnow
   , d1
   , d2
@@ -174,9 +176,17 @@ setCycle = streamSetCycle tidal
 setcps :: Tidally => Pattern Double -> IO ()
 setcps = once . cps
 
--- | See 'Sound.Tidal.Stream.streamGetcps'.
+-- | See 'Sound.Tidal.Stream.streamGetCPS'.
 getcps :: Tidally => IO Time
 getcps = streamGetCPS tidal
+
+-- | See 'Sound.Tidal.Stream.streamGetBPM'.
+setbpm :: Tidally => Time -> IO ()
+setbpm = streamSetBPM tidal
+
+-- | See 'Sound.Tidal.Stream.streamGetBPM'.
+getbpm :: Tidally => IO Time
+getbpm = streamGetBPM tidal
 
 -- | See 'Sound.Tidal.Stream.streamGetnow'.
 getnow :: Tidally => IO Time

--- a/src/Sound/Tidal/Stream/UI.hs
+++ b/src/Sound/Tidal/Stream/UI.hs
@@ -28,11 +28,11 @@ streamResetCycles s = streamSetCycle s 0
 streamSetCycle :: Stream -> Time -> IO ()
 streamSetCycle s = Clock.setClock (sClockRef s)
 
-streamSetBPM :: Stream -> Time -> IO ()
-streamSetBPM s = Clock.setBPM (sClockRef s)
-
 streamSetCPS :: Stream -> Time -> IO ()
 streamSetCPS s = Clock.setCPS (cClockConfig $ sConfig s) (sClockRef s)
+
+streamSetBPM :: Stream -> Time -> IO ()
+streamSetBPM s = Clock.setBPM (sClockRef s)
 
 streamGetCPS :: Stream -> IO Time
 streamGetCPS s = Clock.getCPS (cClockConfig $ sConfig s)(sClockRef s)


### PR DESCRIPTION
We have these functions in the Stream module now, so create aliases in `Boot.hs`

Fixes #1018