### PR TITLE
fix(slice): support `slice 1 _`

### DIFF
--- a/src/Sound/Tidal/Control.hs
+++ b/src/Sound/Tidal/Control.hs
@@ -293,9 +293,13 @@ en ns p = stack $ map (\(i, (k, n)) -> _e k n (samples p (pure i))) $ enumerate 
 -}
 slice :: Pattern Int -> Pattern Int -> ControlPattern -> ControlPattern
 slice pN pI p = P.begin b # P.end e # p
-  where b = div' <$> pI <* pN
-        e = (\i n -> div' i n + div' 1 n) <$> pI <* pN
-        div' num den = fromIntegral (num `mod` den) / fromIntegral den
+  where
+    b = div' <$> pI <* pN
+    e = b + pWidth
+    pWidth = (\x -> 1.0 / fromIntegral x) <$> pN
+    div' :: Int -> Int -> Double
+    div' num den = fromIntegral (num `mod` den) / fromIntegral den
+
 
 _slice :: Int -> Int -> ControlPattern -> ControlPattern
 _slice n i p =

--- a/test/Sound/Tidal/ControlTest.hs
+++ b/test/Sound/Tidal/ControlTest.hs
@@ -41,9 +41,21 @@ run =
         comparePD (Arc 0 1)
           (filterOnsets $ stutWith 4 0.25 (# gain 1) $ sound "bd")
           (filterOnsets $ stut 4 1 0.25 $ sound "bd")
-        
+
     describe "splice" $ do
       it "can beatslice" $ do
         comparePD (Arc 0 1)
           (splice "4 8" "0 1" $ sound "bev")
           (begin "0 0.125" # end "0.25 0.25" # speed "0.5 0.25" # sound "bev" # unit "c")
+
+    describe "slice" $ do
+      it "can slice samples" $ do
+        compareP (Arc 0 1)
+          (slice "8 4" "7 5 0 3 2 4 1 6" $ sound "sn bd")
+          (begin "0.875 0.625 0.0 0.375 0.5 0.0 0.25 0.5" # end "1.0 0.75 0.125 0.5 0.75 0.25 0.5 0.75" # sound "sn bd")
+
+      it "can slice by 1" $ do
+        compareP (Arc 0 1)
+          (slice "1 4" "1 [2 4 1 6]" $ sound "sn bd")
+          (begin "0.0 [0.5 0.0 0.25 0.5]" # end "1.0 [0.75 0.25  0.5 0.75]" # sound "sn bd")
+


### PR DESCRIPTION
fixes: #979

Slice was failing on any slice `pN` of 1. This was because the `begin` of the next slice was being used to calculate the end of the first. With `slice 1 _` all slices begin at `0.0`, so end is incorrectly set to `0.0`.

This implementation calculates the `end` control pattern by generating a sample-width pattern, and adding this to the `begin` pattern.

Two tests are added:

* `slice` "can slice samples" - Regression test that passes on `dev` and this branch
* `slice` "can slice by 1" - Test for accurate calculation of sample end time when slicing into 1