### PR TITLE
Introduces two function families for introducing chromaticism in melodies

### DIFF
--- a/src/Sound/Tidal/Scales.hs
+++ b/src/Sound/Tidal/Scales.hs
@@ -240,6 +240,73 @@ getScale table sp p = (\n scaleName
   where octave s x = x `div` length s
         noteInScale s x = (s !!! x) + fromIntegral (12 * octave s x)
 
+{- Variant of @scale@ allowing to modify the current scale (seen as a list) with an [a] -> [a] function.
+
+These are equivalent:
+
+> d1 $ up (scaleMod "major" (insert 1) $ run 8) # s "superpiano"
+> d1 $ up "0 1 2 4 5 7 9 11" # s "superpiano"
+
+-}
+scaleMod :: (Eq a, Fractional a) => Pattern String -> ([a] -> [a]) -> Pattern Int -> Pattern a
+scaleMod = getScaleMod scaleTable
+
+{- Variant of @scaleMod@ providing a list of modifier functions instead of a single function
+-}
+scaleMods :: (Eq a, Fractional a) => Pattern String -> ([[a] -> [a]]) -> Pattern Int -> Pattern a
+scaleMods sp fs p = slowcat $ map (\f -> scaleMod sp f p) fs
+
+{- Variant of @getScale@ used to build the @scaleMod@ function
+-}
+getScaleMod :: (Eq a, Fractional a) => [(String, [a])] -> Pattern String -> ([a] -> [a]) -> Pattern Int -> Pattern a
+getScaleMod table sp f p = (\n scaleName
+                             -> noteInScale (uniq $ f $ fromMaybe [0] $ lookup scaleName table) n) <$> p <* sp
+  where octave s x = x `div` length s
+        noteInScale s x = (s !!! x) + fromIntegral (12 * octave s x)
+
+{- Eliminates duplicates in a sorted list
+-}
+uniq :: (Eq a) => [a] -> [a]
+uniq (h1:h2:tl) = if (h1 == h2) then h1:(uniq tl) else h1:(uniq (h2:tl))
+uniq l = l
+
+{- Raises a specified degree of a scale, provided as a numbers list.
+Meant to be passed as an argument to @scaleMod@
+-}
+raiseDegree :: Fractional a => Int -> [a] -> [a]
+raiseDegree n (hd:[]) = (hd+1):[]
+raiseDegree 0 (hd:tl) = (hd+1):tl
+raiseDegree n (hd:tl) = hd:(raiseDegree (n-1) tl)
+raiseDegree _ [] = error "Degree is not present in the scale"
+
+{- Lowers a specified degree of a scale, provided as a numbers list.
+Meant to be passed as an argument to @scaleMod@
+-}
+lowerDegree :: Fractional a => Int -> [a] -> [a]
+lowerDegree n (hd:[]) = (hd-1):[] 
+lowerDegree 0 (hd:tl) = (hd-1):tl
+lowerDegree n (hd:tl) = hd:(lowerDegree (n-1) tl)
+lowerDegree _ [] = error "Degree is not present in the scale"
+
+{- Like @raiseDegree@, but raises a range of degrees instead of a single one
+-}
+raiseDegrees :: Fractional a => Int -> Int -> [a] -> [a]
+raiseDegrees n m (hd:[]) = (hd+1):[]
+raiseDegrees 0 0 (hd:tl) = (hd+1):tl
+raiseDegrees 0 m (hd:tl) = (hd+1):(raiseDegrees 0 (m-1) tl)
+raiseDegrees n m (hd:tl) = hd:(raiseDegrees (n-1) (m-1) tl)
+raiseDegrees _ _ [] = error "Degrees are out of the scale"
+
+{- Like @lowerDegree@, but lowers a range of degrees instead of a single one
+-}
+lowerDegrees :: Fractional a => Int -> Int -> [a] -> [a]
+lowerDegrees n m (hd:[]) = (hd-1):[]
+lowerDegrees 0 0 (hd:tl) = (hd-1):tl
+lowerDegrees 0 m (hd:tl) = (hd-1):(lowerDegrees 0 (m-1) tl)
+lowerDegrees n m (hd:tl) = hd:(lowerDegrees (n-1) (m-1) tl)
+lowerDegrees _ _ [] = error "Degrees are out of the scale"
+
+
 {-|
   Outputs this list of all the available scales:
 

--- a/src/Sound/Tidal/Scales.hs
+++ b/src/Sound/Tidal/Scales.hs
@@ -244,19 +244,19 @@ getScale table sp p = (\n scaleName
 
 These are equivalent:
 
-> d1 $ up (scaleMod "major" (insert 1) $ run 8) # s "superpiano"
+> d1 $ up (scaleWith "major" (insert 1) $ run 8) # s "superpiano"
 > d1 $ up "0 1 2 4 5 7 9 11" # s "superpiano"
 
 -}
-scaleMod :: (Eq a, Fractional a) => Pattern String -> ([a] -> [a]) -> Pattern Int -> Pattern a
-scaleMod = getScaleMod scaleTable
+scaleWith :: (Eq a, Fractional a) => Pattern String -> ([a] -> [a]) -> Pattern Int -> Pattern a
+scaleWith = getScaleMod scaleTable
 
-{- Variant of @scaleMod@ providing a list of modifier functions instead of a single function
+{- Variant of @scaleWith@ providing a list of modifier functions instead of a single function
 -}
-scaleMods :: (Eq a, Fractional a) => Pattern String -> ([[a] -> [a]]) -> Pattern Int -> Pattern a
-scaleMods sp fs p = slowcat $ map (\f -> scaleMod sp f p) fs
+scaleWithList :: (Eq a, Fractional a) => Pattern String -> ([[a] -> [a]]) -> Pattern Int -> Pattern a
+scaleWithList sp fs p = slowcat $ map (\f -> scaleWith sp f p) fs
 
-{- Variant of @getScale@ used to build the @scaleMod@ function
+{- Variant of @getScale@ used to build the @scaleWith@ function
 -}
 getScaleMod :: (Eq a, Fractional a) => [(String, [a])] -> Pattern String -> ([a] -> [a]) -> Pattern Int -> Pattern a
 getScaleMod table sp f p = (\n scaleName
@@ -271,7 +271,7 @@ uniq (h1:h2:tl) = if (h1 == h2) then h1:(uniq tl) else h1:(uniq (h2:tl))
 uniq l = l
 
 {- Raises a specified degree of a scale, provided as a numbers list.
-Meant to be passed as an argument to @scaleMod@
+Meant to be passed as an argument to @scaleWith@
 -}
 raiseDegree :: Fractional a => Int -> [a] -> [a]
 raiseDegree n (hd:[]) = (hd+1):[]
@@ -280,7 +280,7 @@ raiseDegree n (hd:tl) = hd:(raiseDegree (n-1) tl)
 raiseDegree _ [] = error "Degree is not present in the scale"
 
 {- Lowers a specified degree of a scale, provided as a numbers list.
-Meant to be passed as an argument to @scaleMod@
+Meant to be passed as an argument to @scaleWith@
 -}
 lowerDegree :: Fractional a => Int -> [a] -> [a]
 lowerDegree n (hd:[]) = (hd-1):[] 

--- a/src/Sound/Tidal/Scales.hs
+++ b/src/Sound/Tidal/Scales.hs
@@ -22,6 +22,7 @@ import Prelude hiding ((<*), (*>))
 import Data.Maybe
 import Sound.Tidal.Pattern
 import Sound.Tidal.Utils
+import Sound.Tidal.Core
 
 -- * Scale definitions
 

--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -2916,3 +2916,21 @@ necklace perCycle xs = _slow ((toRational $ sum xs) / perCycle) $ listToPat $ li
   where list :: [Int] -> [Bool]
         list []      = []
         list (x:xs') = (True:(replicate (x-1) False)) ++ list xs'
+
+{- | Inserts chromatic notes into a pattern.
+
+The first argument indicates the (patternable) number of notes to insert,
+and the second argument is the base pattern of "anchor notes" that gets transformed.
+
+The following are equivalent:
+
+> d1 $ up (chromatiseBy "0 1 2 -1" "[0 2] [3 6] [5 6 8] [3 1 0]") # s "superpiano"
+> d1 $ up "[0 2] [[3 4] [6 7]] [[5 6 7] [6 7 8] [8 9 10] [[3 2] [1 0] [0 -1]]" # s "superpiano"
+-}
+chromatiseBy :: (Num a, Enum a, Ord a) => Pattern a -> Pattern a -> Pattern a
+chromatiseBy n pat = innerJoin $ (\np -> _chromatiseBy np pat) <$> n
+
+_chromatiseBy :: (Num a, Enum a, Ord a) => a -> Pattern a -> Pattern a
+_chromatiseBy n pat = squeezeJoin $ (\value -> fastcat
+                                   $ map pure (if n >=0 then [value .. (value+n)]
+                                               else (reverse $ [(value + n) .. value]))) <$> pat

--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -2924,13 +2924,17 @@ and the second argument is the base pattern of "anchor notes" that gets transfor
 
 The following are equivalent:
 
-> d1 $ up (chromatiseBy "0 1 2 -1" "[0 2] [3 6] [5 6 8] [3 1 0]") # s "superpiano"
+> d1 $ up (chromaticiseBy "0 1 2 -1" "[0 2] [3 6] [5 6 8] [3 1 0]") # s "superpiano"
 > d1 $ up "[0 2] [[3 4] [6 7]] [[5 6 7] [6 7 8] [8 9 10] [[3 2] [1 0] [0 -1]]" # s "superpiano"
 -}
-chromatiseBy :: (Num a, Enum a, Ord a) => Pattern a -> Pattern a -> Pattern a
-chromatiseBy n pat = innerJoin $ (\np -> _chromatiseBy np pat) <$> n
+chromaticiseBy :: (Num a, Enum a, Ord a) => Pattern a -> Pattern a -> Pattern a
+chromaticiseBy n pat = innerJoin $ (\np -> _chromaticiseBy np pat) <$> n
 
-_chromatiseBy :: (Num a, Enum a, Ord a) => a -> Pattern a -> Pattern a
-_chromatiseBy n pat = squeezeJoin $ (\value -> fastcat
+_chromaticiseBy :: (Num a, Enum a, Ord a) => a -> Pattern a -> Pattern a
+_chromaticiseBy n pat = squeezeJoin $ (\value -> fastcat
                                    $ map pure (if n >=0 then [value .. (value+n)]
                                                else (reverse $ [(value + n) .. value]))) <$> pat
+
+-- | Alias for chromaticiseBy
+chromaticizeBy :: (Num a, Enum a, Ord a) => Pattern a -> Pattern a -> Pattern a
+chromaticizeBy = chromaticiseBy


### PR DESCRIPTION
# Context

The contributions of this pull request are described in detail in an article submitted to ICLC 2025. The primary goal of this pull request is to make the related code available to reviewers in context, so that they can manipulate it and test it.

# Content

This introduces two families of functions that aim at facilitating the use of chromaticism in melodies.

* The first family of functions is made up of the `chromatiseBy` function, that introduces chromatic notes in between the anchor notes  given in a pattern. The number of chromatic notes inserted (potentially 0, for no chromaticism, or a negative number, for a descending movement) is a patternable parameter.
* The second family of functions revolves around the `scaleMod` and `scaleMods` functions. 
`scaleMod` is a variant of the `scale` function that takes a supplementary functional `[a] -> [a]` parameter. This parameter is used to transform scales (represented as numbers lists), and allows to functionally transform the current scale. `scaleMods` has a similar role but takes a list of functions rather than a single function.
Other functions in this family include `getScaleMod` (used to build `scaleMod` the same way `getScale` is used to build `scale`), and `raiseDegree`(`s`) and `lowerDegree`(`s`) (meant to be passed as parameters to `scaleMod`(`s`), in order to raise/lower one or a range of degrees in a scale by a semitone).

# Merging

Besides the usual code reviews and implementation considerations, I am not entirely convinced by my naming choices and I think they should be discussed before merging.
* `scaleMod` is short for "scale modification", but the `mod` suffix sounds a little bit too much like "modulo" to my ears (especially given that the `whenmod` function exists). Any suggestions for a more Haskell-idiomatic suffix are very welcome.
* `chromatiseBy` is fine enough in my opinion, but there might be some debate between a British vs an American-style spelling.
