### PR TITLE
flake.nix: update nixpkgs and remove temporary hosc input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,29 +1,12 @@
 {
   "nodes": {
-    "hosc": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1669944828,
-        "narHash": "sha256-cHEf0yEiwNnEpDj7SSQWRMUEAT5USHuuUCPuzOXHWrk=",
-        "owner": "rd--",
-        "repo": "hosc",
-        "rev": "e77aa67cd0b99a32498fef246a687ba443c9b4be",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rd--",
-        "repo": "hosc",
-        "rev": "e77aa67cd0b99a32498fef246a687ba443c9b4be",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687807295,
-        "narHash": "sha256-7TUD0p0m4mZpIi1O+Cyk5NCqpJUnhv/CJOAuHOndjao=",
+        "lastModified": 1730531603,
+        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6b3d1b1cf13f407fef5e634b224d575eb7211975",
+        "rev": "7ffd9ae656aec493492b44d0ddfb28e79a1ea25d",
         "type": "github"
       },
       "original": {
@@ -35,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "hosc": "hosc",
         "nixpkgs": "nixpkgs",
         "utils": "utils"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,14 +23,6 @@
   inputs = {
     utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    # Temporarily add `hosc` at the latest v0.20 commit
-    # (nixpkgs currently only has 0.19.1).
-    # See this comment for details:
-    # https://github.com/tidalcycles/Tidal/pull/1022#issuecomment-1610978403
-    hosc = {
-      url = "github:rd--/hosc?rev=e77aa67cd0b99a32498fef246a687ba443c9b4be";
-      flake = false;
-    };
   };
 
   outputs = inputs: let
@@ -46,7 +38,6 @@
 
     mkPackages = pkgs: let
       project = pkgs.haskellPackages.extend (pkgs.haskell.lib.compose.packageSourceOverrides {
-        hosc = inputs.hosc; # Remove once `hosc` is at 0.20 in nixpkgs.
         tidal = ./.;
         tidal-link = ./tidal-link;
         tidal-listener = ./tidal-listener;


### PR DESCRIPTION
hosc 0.20 is now in nixpkgs-unstable, so the extra input no longer required.