### PR TITLE
CI pipeline repair

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,6 +1,4 @@
-# A set of CI jobs for checking the Nix flake.
-
-name: "nix"
+name: Nix
 on:
   push:
     paths-ignore:
@@ -11,19 +9,19 @@ on:
 
 jobs:
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
 
   nix-fmt-check:
     needs: cancel-previous-runs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: cachix/install-nix-action@v22
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - run: nix fmt -- --check ./
@@ -33,11 +31,11 @@ jobs:
     strategy:
       matrix:
         package: [tidal, tidal-link, tidal-parse]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: cachix/install-nix-action@v22
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - run: nix build --print-build-logs --no-update-lock-file .#${{ matrix.package }}

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -1,0 +1,63 @@
+# partly taken from xmonad stack CI
+name: Stack
+
+on:
+  push:
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  stack:
+    name: stack resolver
+    runs-on: ubuntu-24.04
+    strategy: 
+      matrix:
+        include:
+          - resolver: lts-22
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: cache ~/.stack
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.stack
+          key: stack-${{ runner.os }}-${{ matrix.resolver }}
+
+      - name: install stack and ghc
+        uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+          ghc-version: latest
+
+      - name: Cache Haskell package metadata
+        uses: actions/cache@v4
+        with:
+          path: ~/.stack/pantry
+          key: stack-pantry-${{ runner.os }}-${{ steps.cache-date.outputs.date }}
+
+      - name: Cache Haskell dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.stack/*
+            !~/.stack/pantry
+            !~/.stack/programs
+          key: stack-${{ runner.os }}-${{ matrix.resolver }}-${{ steps.cache-date.outputs.date }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('*.cabal') }}
+          restore-keys: |
+            stack-${{ runner.os }}-${{ matrix.resolver }}-${{ steps.cache-date.outputs.date }}-${{ hashFiles('stack.yaml') }}-
+            stack-${{ runner.os }}-${{ matrix.resolver }}-${{ steps.cache-date.outputs.date }}-
+
+      - name: Update hackage index
+        run: stack update
+
+      - name: test
+        run: |
+            stack test \
+               --fast --no-terminal \
+               --resolver ${{ matrix.resolver }} --system-ghc \
+               --haddock --no-haddock-deps

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name: Linux
+name: Windows
 on:
   push:
     paths-ignore:
@@ -9,41 +9,13 @@ on:
 
 jobs:
   cabal:
-    runs-on: ubuntu-24.04
+    runs-on: windows-latest
     strategy:
       matrix:
         versions:
-          # latest
-          - ghc: latest
-            cabal: latest
-            args: --allow-newer=base,template-haskell
-            experimental: true
-          # a bit newer
-          - ghc: 9.8.2
-            cabal: 3.12.1.0
-            args: --allow-newer=base,template-haskell
-            experimental: false
           # ghcup recommended
           - ghc: 9.4.8
             cabal: 3.12.1.0
-            args: --allow-newer=base,template-haskell
-            experimental: false
-          # debian stable
-          - ghc: 9.0.2
-            cabal: 3.4.1.0
-            args: --allow-newer=base,template-haskell
-            experimental: false
-          ## 8.x
-          - ghc: 8.10.7
-            cabal: 3.6.2.0-p1
-            args: --allow-newer=base,template-haskell
-            experimental: false
-          - ghc: 8.8.4
-            cabal: 3.6.2.0-p1
-            args: --allow-newer=base,template-haskell
-            experimental: false
-          - ghc: 8.6.5
-            cabal: 3.6.2.0-p1
             args: --allow-newer=base,template-haskell
             experimental: false
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 
-Tidal [![Build Status](https://github.com/tidalcycles/Tidal/workflows/ci/badge.svg)](https://github.com/tidalcycles/Tidal/actions)
-=====
+# Tidal <a href="https://github.com/tidalcycles/Tidal/LICENSE"><img alt="License" src="https://img.shields.io/github/license/tidalcycles/Tidal"></a>
 
+<a href="https://github.com/tidalcycles/Tidal/actions/workflows/ci.yml"><img alt="Cabal" src="https://img.shields.io/github/actions/workflow/status/tidalcycles/Tidal/ci.yml?label=Cabal&logo=githubactions&logoColor=white"></a>
+<a href="https://github.com/tidalcycles/Tidal/actions/workflows/stack.yml"><img alt="Stack" src="https://img.shields.io/github/actions/workflow/status/tidalcycles/Tidal/stack.yml?label=Stack&logo=githubactions&logoColor=white"></a>
+<a href="https://github.com/tidalcycles/Tidal/actions/workflows/nix.yml"><img alt="Nix" src="https://img.shields.io/github/actions/workflow/status/tidalcycles/Tidal/nix.yml?label=Nix&logo=githubactions&logoColor=white"></a>
+<a href="https://github.com/tidalcycles/Tidal/actions/workflows/windows.yml"><img alt="Windows" src="https://img.shields.io/github/actions/workflow/status/tidalcycles/Tidal/windows.yml?label=Windows&logo=githubactions&logoColor=white"></a>
+ 
 Language for live coding algorithmic patterns
 
-For documentation, mailing list and more info see here:  
-  https://tidalcycles.org/
+For documentation, mailing list and more info see [here](https://tidalcycles.org/).  
+You can help speed up Tidal development by [contributing to the collective fund](https://opencollective.com/tidalcycles)!
 
-You can help speed up Tidal development by contributing to the collective fund here:  
-  https://opencollective.com/tidalcycles
-
-(c) Alex McLean and contributors, 2022
-
-Distributed under the terms of the GNU Public license version 3 (or later).
-
+(c) Alex McLean and contributors, 2025

--- a/tidal-listener/tidal-listener.cabal
+++ b/tidal-listener/tidal-listener.cabal
@@ -27,7 +27,7 @@ library
                        deepseq,
                        optparse-applicative,
                        tidal >= 1.10 && < 1.11,
-                       hosc >= 0.21 && < 0.22,
+                       hosc >= 0.20 && < 0.21,
                        hint,
                        network
   default-language:    Haskell2010

--- a/tidal.cabal
+++ b/tidal.cabal
@@ -10,10 +10,10 @@ license-file:        LICENSE
 author:              Alex McLean
 maintainer:          Alex McLean <alex@slab.org>, Mike Hodnick <mike.hodnick@gmail.com>
 Stability:           Experimental
-Copyright:           (c) Alex McLean and other contributors, 2021
+Copyright:           (c) Alex McLean and other contributors, 2025
 category:            Sound
 build-type:          Simple
-tested-with:         GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1, GHC == 9.0.1, GHC == 9.4.8, GHC == 9.8.2
+tested-with:         GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.4.8, GHC == 9.8.2
 data-files:          BootTidal.hs
 
 Extra-source-files: README.md CHANGELOG.md tidal.el
@@ -61,7 +61,7 @@ library
       base >=4.8 && <5
     , containers < 0.8
     , colour < 2.4
-    , hosc >= 0.21 && < 0.22
+    , hosc >= 0.20 && < 0.21
     , text < 2.2
     , parsec >= 3.1.12 && < 3.2
     , network < 3.3
@@ -96,7 +96,7 @@ test-suite tests
   build-depends:
                 base ==4.*
               , microspec >= 0.2.0.1
-              , hosc >= 0.21 && < 0.22
+              , hosc >= 0.20 && < 0.21
               , containers
               , parsec
               , tidal


### PR DESCRIPTION
Hi, I updated the workflows to github actions v4 and haskell actions v2. Also
created: dedicated stack and windows CI files to display in the README and for
better separation of concerns. Plus, I downgraded to hosc-0.20 because the
working CI pipelines reveal that there are breaking changes made in hosc-0.21 as
discussed in issue #1103. 

The new GHC entries support  the recommended ghcup GHC/cabal combinations. 
The linux CI also uses the recommended ghcup settings + the debian GHC (9.0.2) and cabal (3.4.1.0)  versions as reference. 

I did not touch the build listener CI/release pipeline; they are still broken but probably less priority than 
the overall build CI and needs to be investigated in a new PR. 

Thanks to the xmonad project: I took a look at their CI/CD -- and their representation of
the pipeline in the README -- as inspiration

![image](https://github.com/user-attachments/assets/728ffd26-41ed-4f1d-a950-a9bdbf533d90)
![image](https://github.com/user-attachments/assets/bcef2357-469f-4574-94ed-b67ea893b993)
![image](https://github.com/user-attachments/assets/152c9909-4dd3-4cf6-8e97-b3dfc6bd972f)
