### PR TITLE
remove extra paren in tidal.el

### DIFF
--- a/tidal.el
+++ b/tidal.el
@@ -346,7 +346,7 @@ Two functions will be created, `tidal-run-NAME' and `tidal-stop-NAME'"
   (local-set-key [?\C-v ?\C-7] 'tidal-stop-d7)
   (local-set-key [?\C-v ?\C-8] 'tidal-stop-d8)
   (local-set-key [?\C-v ?\C-9] 'tidal-stop-d9)
-  (local-set-key [?\C-v ?\C-0] 'tidal-stop-d10)))
+  (local-set-key [?\C-v ?\C-0] 'tidal-stop-d10))
 
 (defun tidal-mode-menu (map)
   "Haskell Tidal menu MAP."


### PR DESCRIPTION
A typo in c278266a96a8d2c00ca670b1b0b3eb777d3f45ae added an extra `)` on line 349 of `tidal.el` which meant that the file wouldn't parse and broke `tidal-mode`. This fixes it.