### PR TITLE
fixed: Parser errors for new rest symbol #1091

### DIFF
--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -345,7 +345,6 @@ instance (Enumerable a, Parseable a) => IsString (Pattern a) where
 lexer :: P.GenTokenParser String u Data.Functor.Identity.Identity
 lexer   = P.makeTokenParser haskellDef
 
-
 braces, brackets, parens, angles:: MyParser a -> MyParser a
 braces p = char '{' Prelude.*> p Prelude.<* char '}'
 brackets p = char '[' Prelude.*> p Prelude.<* char ']'

--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -41,7 +41,7 @@ import           Data.Typeable                          (Typeable)
 import           GHC.Exts                               (IsString (..))
 import           Sound.Tidal.Chords
 import           Sound.Tidal.Core
-import           Sound.Tidal.Pattern hiding             ((*>), (<*))
+import           Sound.Tidal.Pattern
 import           Sound.Tidal.UI
 import           Sound.Tidal.Utils                      (fromRight)
 import           Text.Parsec.Error
@@ -221,20 +221,21 @@ parseBP_E s = toE parsed
     toE (Right tp) = toPat tp
 
 parseTPat :: Parseable a => String -> Either ParseError (TPat a)
-parseTPat = runParser (pSequence parseRest <* eof) (0 :: Int) ""
+parseTPat = runParser (pSequence parseRest Prelude.<* eof) (0 :: Int) ""
 
--- | a '-' is a negative sign if followed by a digit.
+-- | a '-' is a negative sign if followed anything but another dash
 -- otherwise, it's treated as rest
 parseRest :: Parseable a => MyParser (TPat a)
 parseRest = 
   try (do 
         lookAhead $ do
           char '-'
-          digit
+          spaces
+          noneOf "-"
         tPatParser)
-  <|> char '-' *> pure TPat_Silence
+  <|> char '-' Prelude.*> pure TPat_Silence
   <|> tPatParser
-  <|> char '~' *> pure TPat_Silence
+  <|> char '~' Prelude.*> pure TPat_Silence
 
 cP :: (Enumerable a, Parseable a) => String -> Pattern a
 cP s = innerJoin $ parseBP_E <$> _cX_ getS s
@@ -346,10 +347,10 @@ lexer   = P.makeTokenParser haskellDef
 
 
 braces, brackets, parens, angles:: MyParser a -> MyParser a
-braces  = P.braces lexer
-brackets p = char '[' *> p <* char ']'
-parens = P.parens lexer
-angles p = char '<' *> p <* char '>'
+braces p = char '{' Prelude.*> p Prelude.<* char '}'
+brackets p = char '[' Prelude.*> p Prelude.<* char ']'
+parens p = char '(' Prelude.*> p Prelude.<* char ')'
+angles p = char '<' Prelude.*> p Prelude.<* char '>'
 
 symbol :: String -> MyParser String
 symbol  = P.symbol lexer

--- a/test/Sound/Tidal/ParseTest.hs
+++ b/test/Sound/Tidal/ParseTest.hs
@@ -255,6 +255,10 @@ run =
         compareP (Arc 0 1)
           ("- 2" :: Pattern String)
           ("~ 2" :: Pattern String)
+      it "does the same for '-' and '~' in complex patterns parsed as Rational" $ do
+        compareP (Arc 0 1)
+          ("[-- 2 <-- 2@7 3> 4%2 3? 4 9|8 -- [-- <2 9q> -]] 2!4" :: Pattern Rational)
+          ("[~~ 2 <~~ 2@7 3> 4%2 3? 4 9|8 ~~ [~~ <2 9q> ~]] 2!4" :: Pattern Rational)
       it "does the same for '-' and '~' in complex patterns" $ do
         compareP (Arc 0 1)
           ("[-- 2 <-- 2@7 3> 1*4%2 3? 4 9|8 -- [-- <2 9q> -]] 2!4" :: Pattern String)

--- a/test/Sound/Tidal/ParseTest.hs
+++ b/test/Sound/Tidal/ParseTest.hs
@@ -257,8 +257,8 @@ run =
           ("~ 2" :: Pattern String)
       it "does the same for '-' and '~' in complex patterns" $ do
         compareP (Arc 0 1)
-          ("[-- 2 <-- 2@7 3> 3%4 9|8 -- [-- <2 9q> -]] 2!4" :: Pattern String)
-          ("[~~ 2 <~~ 2@7 3> 3%4 9|8 ~~ [~~ <2 9q> ~]] 2!4" :: Pattern String)
+          ("[-- 2 <-- 2@7 3> 1*4%2 3? 4 9|8 -- [-- <2 9q> -]] 2!4" :: Pattern String)
+          ("[~~ 2 <~~ 2@7 3> 1*4%2 3? 4 9|8 ~~ [~~ <2 9q> ~]] 2!4" :: Pattern String)
       it "does the same for '-' and '~' using rational numbers" $ do
         compareP (Arc 0 1)
           ("- 2q -3.999-9" :: Pattern String)
@@ -269,6 +269,6 @@ run =
           ("[~~ 2 ~~ ~]" :: Pattern String)
       it "does the same for '-' and '~' alternating patterns" $ do
         compareP (Arc 0 1)
-          ("<-- 2 -- ->" :: Pattern String)
-          ("<~~ 2 ~~ ~>" :: Pattern String)
+          ("<-- 2 -- - 8>" :: Pattern String)
+          ("<~~ 2 ~~ ~ 8>" :: Pattern String)
     where degradeByDefault = _degradeBy 0.5

--- a/test/Sound/Tidal/ParseTest.hs
+++ b/test/Sound/Tidal/ParseTest.hs
@@ -251,4 +251,24 @@ run =
         compareP (Arc 0 1)
           ("t*2t t" :: Pattern Bool)
           ("1*2%3 1" :: Pattern Bool)
+      it "does the same for '-' and '~' in simple patterns" $ do
+        compareP (Arc 0 1)
+          ("- 2" :: Pattern String)
+          ("~ 2" :: Pattern String)
+      it "does the same for '-' and '~' in complex patterns" $ do
+        compareP (Arc 0 1)
+          ("[-- 2 <-- 2@7 3> 3%4 9|8 -- [-- <2 9q> -]] 2!4" :: Pattern String)
+          ("[~~ 2 <~~ 2@7 3> 3%4 9|8 ~~ [~~ <2 9q> ~]] 2!4" :: Pattern String)
+      it "does the same for '-' and '~' using rational numbers" $ do
+        compareP (Arc 0 1)
+          ("- 2q -3.999-9" :: Pattern String)
+          ("~ 2q -3.999-9" :: Pattern String)
+      it "does the same for '-' and '~' in list patterns" $ do
+        compareP (Arc 0 1)
+          ("[-- 2 -- -]" :: Pattern String)
+          ("[~~ 2 ~~ ~]" :: Pattern String)
+      it "does the same for '-' and '~' alternating patterns" $ do
+        compareP (Arc 0 1)
+          ("<-- 2 -- ->" :: Pattern String)
+          ("<~~ 2 ~~ ~>" :: Pattern String)
     where degradeByDefault = _degradeBy 0.5


### PR DESCRIPTION
as described in #1091 

the 'edge cases' resolved were:
1. the '-' could be a negative number or part of a rational number.
2. the angles and brackets tokenization from native Parsec behave weird.

puh! this was a tough one for me to find because of point 2.

Tests work, so if @yaxu gives his ok, this can be merged.