### PR TITLE
CI on tidal-listener execute on changes only

### DIFF
--- a/.github/workflows/listener-build-linux.yml
+++ b/.github/workflows/listener-build-linux.yml
@@ -1,11 +1,11 @@
 name: build-listener-linux
 on:
   push:
-    paths-ignore:
-      - "**.md"
+    paths:
+      - "tidal-listener/**"
   pull_request:
-    paths-ignore:
-      - "**.md"
+    paths:
+      - "tidal-listener/**"
 
 jobs:
   build:

--- a/.github/workflows/listener-build-macosx.yml
+++ b/.github/workflows/listener-build-macosx.yml
@@ -1,11 +1,11 @@
 name: build-listener-macosx
 on:
   push:
-    paths-ignore:
-      - "**.md"
+    paths:
+      - "tidal-listener/**"
   pull_request:
-    paths-ignore:
-      - "**.md"
+    paths:
+      - "tidal-listener/**"
 
 jobs:
   build:

--- a/.github/workflows/listener-build-windows.yml
+++ b/.github/workflows/listener-build-windows.yml
@@ -1,11 +1,11 @@
 name: build-listener-windows
 on:
   push:
-    paths-ignore:
-      - "**.md"
+    paths:
+      - "tidal-listener/**"
   pull_request:
-    paths-ignore:
-      - "**.md"
+    paths:
+      - "tidal-listener/**"
 
 jobs:
   build:


### PR DESCRIPTION
As I understand tidal-listener is not used in Tidal or tidal-link itself and currently a bit broken as mentioned in #1092.

Therefore it does not make sense to me to run the full CI (which works towards a packaged release, I think) on every change in Tidal or tidal-link. If I'm wrong, feel free to just close this :)