### PR TITLE
[redo] fix beat function for "step sequencer" style notation (error on last fractional notes)

### DIFF
--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -1474,7 +1474,7 @@ __beat :: (Pattern (Pattern a) -> Pattern a) -> Time -> Time -> Pattern a -> Pat
 __beat usejoin t d p = usejoin $ compress (s, e) . pure <$> p
   where
     s = t' / d
-    e = (t' + 1) / d
+    e  = min 1 $ (t' + 1) / d
     t' = t `mod'` d
 
 -- |

--- a/src/Sound/Tidal/UI.hs
+++ b/src/Sound/Tidal/UI.hs
@@ -1474,7 +1474,7 @@ __beat :: (Pattern (Pattern a) -> Pattern a) -> Time -> Time -> Pattern a -> Pat
 __beat usejoin t d p = usejoin $ compress (s, e) . pure <$> p
   where
     s = t' / d
-    e  = min 1 $ (t' + 1) / d
+    e = min 1 $ (t' + 1) / d
     t' = t `mod'` d
 
 -- |


### PR DESCRIPTION
redo of #1126 for merging reasons

---

this was just pushed on #1109 

but there was a loose edge case, that is, fractional notes on the upper bound of the divisor. `compress` can't work on ends bigger than `1`, so I added a `min` operator which would squeeze them to fit

see:

```hs
__beat :: (Pattern (Pattern a) -> Pattern a) -> Time -> Time -> Pattern a -> Pattern a
__beat join t d p = join $ (compress (s,e) . pure) <$> p
                      where s = t' / d
                            e  = min 1 $ (t'+1) / d
                            t' = t `mod'` d
```

this error is also present in strudel