### PR TITLE
WIP: top level stack pattern

### DIFF
--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -448,7 +448,6 @@ pChoice f a =
 
 -- so far, the first pattern in stack has to be single
 -- '1 2, 3 4' results in '1 [2, 3 4]'
--- also: no elongate or repeat working in first to be stacked (single) pattern
 pStack :: (Parseable a) => MyParser (TPat a) -> TPat a -> MyParser (TPat a)
 pStack f a = do
   try $ do

--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -236,9 +236,11 @@ parseRest =
           noneOf "-"
         tPatParser
     )
-    <|> char '-' *> pure TPat_Silence
+    <|> char '-'
+    *> pure TPat_Silence
       <|> tPatParser
-      <|> char '~' *> pure TPat_Silence
+      <|> char '~'
+    *> pure TPat_Silence
 
 cP :: (Enumerable a, Parseable a) => String -> Pattern a
 cP s = innerJoin $ parseBP_E <$> _cX_ getS s

--- a/test/Sound/Tidal/ParseTest.hs
+++ b/test/Sound/Tidal/ParseTest.hs
@@ -355,20 +355,15 @@ run =
           (Arc 0 1)
           ("1 2, 3 4 5" :: Pattern String)
           (stack ["1 2", "3 4 5"])
-      it "toplevel ',' is the same as in list" $ do
+      it "simple toplevel ',' is the same as in list" $ do
         compareP
           (Arc 0 1)
           ("1,2 3" :: Pattern String)
           (stack ["1", "2 3"])
-      it "toplevel ',' with elongate" $ do
+      it "toplevel ','. single leading pattern with elongate" $ do
         compareP
           (Arc 0 1)
-          ("1!2 8*2,2|3,3 9 8" :: Pattern String)
-          (stack ["1!2 8*2", "2|3", "3 9 8"])
-      it "toplevel ',' more complex pattern" $ do
-        compareP
-          (Arc 0 1)
-          ("7 12,2*3,2!2, 4" :: Pattern String)
-          ("[7 12,2*3,2!2, 4]" :: Pattern String)
+          ("8@2,2|3,3 9 8" :: Pattern String)
+          (stack ["8@2", "2|3", "3 9 8"])
   where
     degradeByDefault = _degradeBy 0.5

--- a/test/Sound/Tidal/ParseTest.hs
+++ b/test/Sound/Tidal/ParseTest.hs
@@ -339,8 +339,8 @@ run =
       it "toplevel '|' is the same as in list" $ do
         compareP
           (Arc 0 1)
-          ("[a a|b b b|c c c c]" :: Pattern String)
           ("a a |b b b|c c c c" :: Pattern String)
+          ("[a a|b b b|c c c c]" :: Pattern String)
       it "'|' in list first" $ do
         evaluate ("1 2@3|4|-|5!6|[7!8 9] 10 . 11 12*2 13!2 . 1@1" :: Pattern String)
           `shouldNotThrow` anyException
@@ -358,12 +358,12 @@ run =
       it "simple toplevel ',' is the same as in list" $ do
         compareP
           (Arc 0 1)
-          ("1,2 3" :: Pattern String)
-          (stack ["1", "2 3"])
+          ("9!2 1,2 3" :: Pattern String)
+          (stack ["9!2 1", "2 3"])
       it "toplevel ','. single leading pattern with elongate" $ do
         compareP
           (Arc 0 1)
-          ("8@2,2|3,3 9 8" :: Pattern String)
-          (stack ["8@2", "2|3", "3 9 8"])
+          ("8@2 4, [23 | 4] , 3 9 8" :: Pattern String)
+          (stack ["8@2 4", "23|4", "3 9 8"])
   where
     degradeByDefault = _degradeBy 0.5

--- a/test/Sound/Tidal/ParseTest.hs
+++ b/test/Sound/Tidal/ParseTest.hs
@@ -350,5 +350,25 @@ run =
       it "toplevel '|'" $ do
         evaluate ("121|23@1|12|[1 321]" :: Pattern String)
           `shouldNotThrow` anyException
+      it "list is same as stack" $ do
+        compareP
+          (Arc 0 1)
+          ("1 2, 3 4 5" :: Pattern String)
+          (stack ["1 2", "3 4 5"])
+      it "toplevel ',' is the same as in list" $ do
+        compareP
+          (Arc 0 1)
+          ("1,2 3" :: Pattern String)
+          (stack ["1", "2 3"])
+      it "toplevel ',' with elongate" $ do
+        compareP
+          (Arc 0 1)
+          ("1!2 8*2,2|3,3 9 8" :: Pattern String)
+          (stack ["1!2 8*2", "2|3", "3 9 8"])
+      it "toplevel ',' more complex pattern" $ do
+        compareP
+          (Arc 0 1)
+          ("7 12,2*3,2!2, 4" :: Pattern String)
+          ("[7 12,2*3,2!2, 4]" :: Pattern String)
   where
     degradeByDefault = _degradeBy 0.5


### PR DESCRIPTION
so far, the first pattern in the top-level stack has to be a single value
eg: `1 2, 3 4` results in `1 [2, 3 4]`. Where in Strudel it would become `[1 2, 3 4]`
also: no elongate or repeat working in first to be stacked (single) pattern

maybe @polymorphicengine could give a comment on the overall approach.

would resolve #980.