### PR TITLE
[breaking change] sample signals at query onsets instead of midpoint

### DIFF
--- a/src/Sound/Tidal/Core.hs
+++ b/src/Sound/Tidal/Core.hs
@@ -40,7 +40,7 @@ sig f = pattern q
   where
     q (State (Arc s e) _)
       | s > e = []
-      | otherwise = [Event (Context []) Nothing (Arc s e) (f (s + ((e - s) / 2)))]
+      | otherwise = [Event (Context []) Nothing (Arc s e) (f s)]
 
 -- | @sine@ - unipolar sinewave. A pattern of continuous values following a
 -- sinewave with frequency of one cycle, and amplitude from 0 to 1.

--- a/test/Sound/Tidal/CoreTest.hs
+++ b/test/Sound/Tidal/CoreTest.hs
@@ -296,21 +296,21 @@ run =
         map value (queryArc ((+ 1) <$> saw) (Arc 0.5 0.5)) `shouldBe` [1.5 :: Float]
       it "works on the left of <*>" $
         queryArc ((+) <$> saw <*> pure 3) (Arc 0 1)
-          `shouldBe` [Event (Context []) Nothing (Arc 0 1) 3.5 :: Event Double]
+          `shouldBe` [Event (Context []) Nothing (Arc 0 1) 3 :: Event Double]
       it "works on the right of <*>" $
         queryArc (fast 4 (pure (+ 3)) <*> saw) (Arc 0 1)
-          `shouldBe` [ Event (Context []) Nothing (Arc 0 0.25) 3.5 :: Event Double,
-                       Event (Context []) Nothing (Arc 0.25 0.5) 3.5,
-                       Event (Context []) Nothing (Arc 0.5 0.75) 3.5,
-                       Event (Context []) Nothing (Arc 0.75 1) 3.5
+          `shouldBe` [ Event (Context []) Nothing (Arc 0 0.25) 3 :: Event Double,
+                       Event (Context []) Nothing (Arc 0.25 0.5) 3,
+                       Event (Context []) Nothing (Arc 0.5 0.75) 3,
+                       Event (Context []) Nothing (Arc 0.75 1) 3
                      ]
       it "can be reversed" $ do
         it "works with whole cycles" $
           queryArc (rev saw) (Arc 0 1)
-            `shouldBe` [Event (Context []) Nothing (Arc 0 1) 0.5 :: Event Double]
+            `shouldBe` [Event (Context []) Nothing (Arc 0 1) 0 :: Event Double]
         it "works with half cycles" $
-          queryArc (rev saw) (Arc 0 0.5)
-            `shouldBe` [Event (Context []) Nothing (Arc 0 0.5) 0.75 :: Event Double]
+          queryArc (rev saw) (Arc 0.5 1)
+            `shouldBe` [Event (Context []) Nothing (Arc 0.5 1) 0 :: Event Double]
         it "works with inset points" $
           queryArc (rev saw) (Arc 0.25 0.25)
             `shouldBe` [Event (Context []) Nothing (Arc 0.25 0.25) 0.75 :: Event Double]
@@ -320,12 +320,12 @@ run =
         comparePD
           (Arc 0 1)
           (struct "t*8" (tri :: Pattern Double))
-          "0.125 0.375 0.625 0.875 0.875 0.625 0.375 0.125"
+          "0 0.25 0.5 0.75 1 0.75 0.5 0.25"
       it "can be added to" $
         comparePD
           (Arc 0 1)
           (struct "t*8" $ (tri :: Pattern Double) + 1)
-          "1.125 1.375 1.625 1.875 1.875 1.625 1.375 1.125"
+          "1 1.25 1.5 1.75 2 1.75 1.5 1.25"
     describe "every" $
       it "`every n id` doesn't change the pattern's structure" $ do
         comparePD

--- a/test/Sound/Tidal/PatternTest.hs
+++ b/test/Sound/Tidal/PatternTest.hs
@@ -216,7 +216,7 @@ run =
                      ]
       it "preserves cycle number of inner patterns" $ do
         (map value $ queryArc (squeezeJoin (pure $ struct "1" $ (sig $ id))) (Arc 3 4))
-          `shouldBe` [3.5]
+          `shouldBe` [3]
 
     describe ">>=" $ do
       it "can apply functions to patterns" $ do
@@ -530,7 +530,7 @@ run =
       it "filter above given threshold" $ do
         let fil = stripContext $ filterWhen (> 0.5) $ struct "t*4" $ (tri :: Pattern Double) + 1
         let res = queryArc fil (Arc 0.5 1.5)
-        property $ fmap toEvent [(((3 % 4, 1), (3 % 4, 1)), 1.25), (((1, 5 % 4), (1, 5 % 4)), 1.25), (((5 % 4, 3 % 2), (5 % 4, 3 % 2)), 1.75)] === res
+        property $ fmap toEvent [(((3 % 4, 1), (3 % 4, 1)), 1.5), (((1, 5 % 4), (1, 5 % 4)), 1), (((5 % 4, 3 % 2), (5 % 4, 3 % 2)), 1.5)] === res
 
     describe "compressArc" $ do
       it "return empty if start time is greater than end time" $ do

--- a/test/Sound/Tidal/UITest.hs
+++ b/test/Sound/Tidal/UITest.hs
@@ -42,7 +42,7 @@ run =
         compareP
           (Arc 0 3)
           (segment 4 saw)
-          ("0.125 0.375 0.625 0.875" :: Pattern Double)
+          ("0 0.25 0.5 0.75" :: Pattern Double)
       it "can hold a value over multiple cycles" $ do
         comparePD
           (Arc 0 8)
@@ -377,7 +377,7 @@ run =
         compareP
           (Arc 0 4)
           ("0" |+ chooseBy (sig fromRational) [0, 1, 2, 3])
-          ("2" :: Pattern Int)
+          ("0" :: Pattern Int)
 
     describe "arpeggiate" $ do
       it "can arpeggiate" $ do
@@ -479,4 +479,4 @@ run =
         compareP
           (Arc 0 1)
           (segment 2 $ quantise 1 $ sine :: Pattern Note)
-          ("1 0" :: Pattern Note)
+          ("0 1" :: Pattern Note)


### PR DESCRIPTION
This changes almost everything involving signals, including all use of random numbers. However it makes more sense to sample at onsets, as discrete event composition is all about onsets.