### PR TITLE
Toplevel ',' and '|'. 

### DIFF
--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -38,6 +38,7 @@ import Data.List (intercalate)
 import Data.Maybe
 import Data.Ratio
 import Data.Typeable (Typeable)
+import Data.Functor (($>))
 import GHC.Exts (IsString (..))
 import Sound.Tidal.Chords
 import Sound.Tidal.Core
@@ -236,11 +237,9 @@ parseRest =
           noneOf "-"
         tPatParser
     )
-    <|> char '-'
-    *> pure TPat_Silence
+    <|> char '-' $> TPat_Silence
       <|> tPatParser
-      <|> char '~'
-    *> pure TPat_Silence
+      <|> char '~' $> TPat_Silence
 
 cP :: (Enumerable a, Parseable a) => String -> Pattern a
 cP s = innerJoin $ parseBP_E <$> _cX_ getS s

--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -33,12 +33,12 @@ import qualified Control.Exception as E
 import Data.Bifunctor (first)
 import Data.Colour
 import Data.Colour.Names
+import Data.Functor (($>))
 import Data.Functor.Identity (Identity)
 import Data.List (intercalate)
 import Data.Maybe
 import Data.Ratio
 import Data.Typeable (Typeable)
-import Data.Functor (($>))
 import GHC.Exts (IsString (..))
 import Sound.Tidal.Chords
 import Sound.Tidal.Core
@@ -237,9 +237,11 @@ parseRest =
           noneOf "-"
         tPatParser
     )
-    <|> char '-' $> TPat_Silence
+    <|> char '-'
+    $> TPat_Silence
       <|> tPatParser
-      <|> char '~' $> TPat_Silence
+      <|> char '~'
+    $> TPat_Silence
 
 cP :: (Enumerable a, Parseable a) => String -> Pattern a
 cP s = innerJoin $ parseBP_E <$> _cX_ getS s
@@ -485,7 +487,7 @@ newSeed = do
   return seed
 
 pPolyIn :: (Parseable a) => MyParser (TPat a) -> MyParser (TPat a)
-pPolyIn f = do 
+pPolyIn f = do
   x <- brackets $ pTidal f
   pMult x
 

--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -485,7 +485,9 @@ newSeed = do
   return seed
 
 pPolyIn :: (Parseable a) => MyParser (TPat a) -> MyParser (TPat a)
-pPolyIn f = brackets $ pTidal f
+pPolyIn f = do 
+  x <- brackets $ pTidal f
+  pMult x
 
 pPolyOut :: (Parseable a) => MyParser (TPat a) -> MyParser (TPat a)
 pPolyOut f =

--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -236,9 +236,11 @@ parseRest =
           noneOf "-"
         tPatParser
     )
-    <|> char '-' *> pure TPat_Silence
+    <|> char '-'
+    *> pure TPat_Silence
       <|> tPatParser
-      <|> char '~' *> pure TPat_Silence
+      <|> char '~'
+    *> pure TPat_Silence
 
 cP :: (Enumerable a, Parseable a) => String -> Pattern a
 cP s = innerJoin $ parseBP_E <$> _cX_ getS s

--- a/src/Sound/Tidal/ParseBP.hs
+++ b/src/Sound/Tidal/ParseBP.hs
@@ -41,7 +41,7 @@ import Data.Typeable (Typeable)
 import GHC.Exts (IsString (..))
 import Sound.Tidal.Chords
 import Sound.Tidal.Core
-import Sound.Tidal.Pattern
+import Sound.Tidal.Pattern hiding ((*>), (<*))
 import Sound.Tidal.UI
 import Sound.Tidal.Utils (fromRight)
 import Text.Parsec.Error
@@ -222,7 +222,7 @@ parseBP_E s = toE parsed
     toE (Right tp) = toPat tp
 
 parseTPat :: (Parseable a) => String -> Either ParseError (TPat a)
-parseTPat = runParser (pSequence parseRest Prelude.<* eof) (0 :: Int) ""
+parseTPat = runParser (pTidal parseRest <* eof) (0 :: Int) ""
 
 -- | a '-' is a negative sign if followed anything but another dash
 -- otherwise, it's treated as rest
@@ -236,11 +236,9 @@ parseRest =
           noneOf "-"
         tPatParser
     )
-    <|> char '-'
-    Prelude.*> pure TPat_Silence
+    <|> char '-' *> pure TPat_Silence
       <|> tPatParser
-      <|> char '~'
-    Prelude.*> pure TPat_Silence
+      <|> char '~' *> pure TPat_Silence
 
 cP :: (Enumerable a, Parseable a) => String -> Pattern a
 cP s = innerJoin $ parseBP_E <$> _cX_ getS s
@@ -353,10 +351,10 @@ lexer :: P.GenTokenParser String u Data.Functor.Identity.Identity
 lexer = P.makeTokenParser haskellDef
 
 braces, brackets, parens, angles :: MyParser a -> MyParser a
-braces p = char '{' Prelude.*> p Prelude.<* char '}'
-brackets p = char '[' Prelude.*> p Prelude.<* char ']'
-parens p = char '(' Prelude.*> p Prelude.<* char ')'
-angles p = char '<' Prelude.*> p Prelude.<* char '>'
+braces p = char '{' *> p <* char '}'
+brackets p = char '[' *> p <* char ']'
+parens p = char '(' *> p <* char ')'
+angles p = char '<' *> p <* char '>'
 
 symbol :: String -> MyParser String
 symbol = P.symbol lexer
@@ -391,6 +389,26 @@ sign =
 intOrFloat :: MyParser Double
 intOrFloat = try pFloat <|> pInteger
 
+-- | parser starting point
+pTidal :: (Parseable a) => MyParser (TPat a) -> MyParser (TPat a)
+pTidal f = do
+  x <- do
+    s <- pSequence f <?> "sequence"
+    stackTail s <|> chooseTail s <|> return s
+  pMult x
+  where
+    stackTail s = do
+      symbol ","
+      ss <- pSequence f `sepBy` symbol ","
+      return $ TPat_Stack (s : ss)
+    chooseTail s = do
+      symbol "|"
+      ss <- pSequence f `sepBy` symbol "|"
+      seed <- newSeed
+      return $ TPat_CycleChoose seed (s : ss)
+
+-- | Try different parsers on a sequence of Tidal patterns
+-- 'f' is the sequence so far, 'a' the next upcoming token/non-terminal
 pSequence :: (Parseable a) => MyParser (TPat a) -> MyParser (TPat a)
 pSequence f = do
   spaces
@@ -399,26 +417,11 @@ pSequence f = do
       do
         a <- pPart f
         spaces
-        do
-          try $ symbol ".."
-          b <- pPart f
-          return $ TPat_EnumFromTo a b
-          <|> try
-            ( do
-                lookAhead
-                  ( char '|'
-                      <|> do
-                        pElongate a <|> pRepeat a
-                        char '|'
-                  )
-                pChoice f a
-            )
+        pEnumeration f a
           <|> pElongate a
           <|> pRepeat a
           <|> return a
-        <|> do
-          symbol "."
-          return TPat_Foot
+        <|> pFoot
   pRand $ resolve_feet s
   where
     resolve_feet ps
@@ -435,17 +438,14 @@ pSequence f = do
         takeFoot (TPat_Foot : pats'') = ([], pats'')
         takeFoot (pat : pats'') = first (pat :) $ takeFoot pats''
 
-pChoice :: (Parseable a) => MyParser (TPat a) -> TPat a -> MyParser (TPat a)
-pChoice f a = do
-  eor <- option (TPat_Seq []) (pElongate a <|> pRepeat a)
-  cs <- many1 $
-    do
-      char '|'
-      b <- pPart f
-      pElongate b <|> pRepeat b <|> return b
-  seed <- newSeed
-  rest <- option (TPat_Seq []) (pSequence f)
-  return $ TPat_Seq [TPat_CycleChoose seed (eor : (a : cs)), rest]
+pFoot :: MyParser (TPat a)
+pFoot = symbol "." >> return TPat_Foot
+
+pEnumeration :: (Parseable a) => MyParser (TPat a) -> TPat a -> MyParser (TPat a)
+pEnumeration f a = do
+  try $ symbol ".."
+  b <- pPart f
+  return $ TPat_EnumFromTo a b
 
 pRepeat :: TPat a -> MyParser (TPat a)
 pRepeat a = do
@@ -484,21 +484,7 @@ newSeed = do
   return seed
 
 pPolyIn :: (Parseable a) => MyParser (TPat a) -> MyParser (TPat a)
-pPolyIn f = do
-  x <- brackets $ do
-    s <- pSequence f <?> "sequence"
-    stackTail s <|> chooseTail s <|> return s
-  pMult x
-  where
-    stackTail s = do
-      symbol ","
-      ss <- pSequence f `sepBy` symbol ","
-      return $ TPat_Stack (s : ss)
-    chooseTail s = do
-      symbol "|"
-      ss <- pSequence f `sepBy` symbol "|"
-      seed <- newSeed
-      return $ TPat_CycleChoose seed (s : ss)
+pPolyIn f = brackets $ pTidal f
 
 pPolyOut :: (Parseable a) => MyParser (TPat a) -> MyParser (TPat a)
 pPolyOut f =
@@ -684,6 +670,7 @@ pRand thing =
     return $ TPat_DegradeBy seed r thing
     <|> return thing
 
+-- | parse Euclidean notation like 'bd(3,8)'
 pE :: TPat a -> MyParser (TPat a)
 pE thing =
   do

--- a/test/Sound/Tidal/ParseTest.hs
+++ b/test/Sound/Tidal/ParseTest.hs
@@ -339,8 +339,8 @@ run =
       it "toplevel '|' is the same as in list" $ do
         compareP
           (Arc 0 1)
-          ("[a a|b b b|c c c c]" :: Pattern String)
           ("a a |b b b|c c c c" :: Pattern String)
+          ("[a a|b b b|c c c c]" :: Pattern String)
       it "'|' in list first" $ do
         evaluate ("1 2@3|4|-|5!6|[7!8 9] 10 . 11 12*2 13!2 . 1@1" :: Pattern String)
           `shouldNotThrow` anyException
@@ -350,5 +350,20 @@ run =
       it "toplevel '|'" $ do
         evaluate ("121|23@1|12|[1 321]" :: Pattern String)
           `shouldNotThrow` anyException
+      it "list is same as stack" $ do
+        compareP
+          (Arc 0 1)
+          ("1 2, 3 4 5" :: Pattern String)
+          (stack ["1 2", "3 4 5"])
+      it "simple toplevel ',' is the same as in list" $ do
+        compareP
+          (Arc 0 1)
+          ("9!2 1,2 3" :: Pattern String)
+          (stack ["9!2 1", "2 3"])
+      it "toplevel ','. single leading pattern with elongate" $ do
+        compareP
+          (Arc 0 1)
+          ("8@2 4, [23 | 4] , 3 9 8" :: Pattern String)
+          (stack ["8@2 4", "23|4", "3 9 8"])
   where
     degradeByDefault = _degradeBy 0.5


### PR DESCRIPTION
fixed code to pass tidal-parse tests.
