### PR TITLE
link and clock setter functions

### DIFF
--- a/BootTidal.hs
+++ b/BootTidal.hs
@@ -16,8 +16,9 @@ tidalInst <- mkTidal
 -- It has to go after you define 'tidalInst'.
 instance Tidally where tidal = tidalInst
 
--- Uncomment to enable Ableton Link on startup:
--- streamEnableLink tidal
+-- `enableLink` and `disableLink` can be used to toggle Ableton Link.
+-- Uncomment the next line to enable Ableton Link on startup.
+-- enableLink
 
 -- You can add your own aliases in this file. Here are some examples:
 -- :{

--- a/src/Sound/Tidal/Boot.hs
+++ b/src/Sound/Tidal/Boot.hs
@@ -32,6 +32,8 @@ module Sound.Tidal.Boot
     setbpm,
     getbpm,
     getnow,
+    enableLink,
+    disableLink,
     d1,
     d2,
     d3,
@@ -127,11 +129,11 @@ mkOscMap = [(superdirtTarget {oLatency = 0.05, oAddress = "127.0.0.1", oPort = 5
 
 -- | Creates a Tidal instance using default config. Use 'mkTidalWith' to customize.
 mkTidal :: IO Stream
-mkTidal = mkTidalWith defaultConfig mkOscMap
+mkTidal = mkTidalWith mkOscMap defaultConfig
 
 -- | See 'Sound.Tidal.Stream.startStream'.
-mkTidalWith :: Config -> OscMap -> IO Stream
-mkTidalWith config oscmap = do
+mkTidalWith :: OscMap -> Config -> IO Stream
+mkTidalWith oscmap config = do
   hSetEncoding stdout utf8
   startStream config oscmap
 
@@ -233,6 +235,12 @@ getbpm = streamGetBPM tidal
 -- | See 'Sound.Tidal.Stream.streamGetnow'.
 getnow :: (Tidally) => IO Time
 getnow = streamGetNow tidal
+
+enableLink :: (Tidally) => IO ()
+enableLink = streamEnableLink tidal
+
+disableLink :: (Tidally) => IO ()
+disableLink = streamDisableLink tidal
 
 -- | Replace what's playing on the given orbit.
 d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16 :: (Tidally) => ControlPattern -> IO ()

--- a/src/Sound/Tidal/Stream/Config.hs
+++ b/src/Sound/Tidal/Stream/Config.hs
@@ -51,10 +51,13 @@ verbose :: Config -> String -> IO ()
 verbose c s = when (cVerbose c) $ putStrLn s
 
 setFrameTimespan :: Double -> Config -> Config
-setFrameTimespan n c = c 
-  { cClockConfig = (cClockConfig c) { Clock.cFrameTimespan = n } }
+setFrameTimespan n c =
+  c
+    { cClockConfig = (cClockConfig c) {Clock.cFrameTimespan = n}
+    }
 
 setProcessAhead :: Double -> Config -> Config
-setProcessAhead n c = c 
-  { cClockConfig = (cClockConfig c) { Clock.cProcessAhead = n } }
-
+setProcessAhead n c =
+  c
+    { cClockConfig = (cClockConfig c) {Clock.cProcessAhead = n}
+    }

--- a/src/Sound/Tidal/Stream/Config.hs
+++ b/src/Sound/Tidal/Stream/Config.hs
@@ -49,3 +49,12 @@ defaultConfig =
 
 verbose :: Config -> String -> IO ()
 verbose c s = when (cVerbose c) $ putStrLn s
+
+setFrameTimespan :: Double -> Config -> Config
+setFrameTimespan n c = c 
+  { cClockConfig = (cClockConfig c) { Clock.cFrameTimespan = n } }
+
+setProcessAhead :: Double -> Config -> Config
+setProcessAhead n c = c 
+  { cClockConfig = (cClockConfig c) { Clock.cProcessAhead = n } }
+

--- a/src/Sound/Tidal/Stream/UI.hs
+++ b/src/Sound/Tidal/Stream/UI.hs
@@ -63,7 +63,7 @@ streamReplace stream k !pat = do
   E.handle
     ( \(e :: E.SomeException) -> do
         hPutStrLn stderr $ "Failed to Stream.streamReplace: " ++ show e
-        hPutStrLn stderr $ "Return to previous pattern."
+        hPutStrLn stderr "Return to previous pattern."
         setPreviousPatternOrSilence (sPMapMV stream)
     )
     (updatePattern stream k t pat)

--- a/tidal-core/src/Sound/Tidal/Params.hs
+++ b/tidal-core/src/Sound/Tidal/Params.hs
@@ -1709,6 +1709,9 @@ legatoCountTo name ipat = innerJoin $ (\i -> pStateF "legato" name (maybe 0 ((`m
 legatobus :: Pattern Int -> Pattern Double -> ControlPattern
 legatobus _ _ = error $ "Control parameter 'legato' can't be sent to a bus."
 
+clip :: Pattern Double -> ControlPattern
+clip = legato
+
 leslie :: Pattern Double -> ControlPattern
 leslie = pF "leslie"
 


### PR DESCRIPTION
the setters allow to define clock latencies via, as discussed in https://github.com/tidalcycles/tidal-doc/issues/289. I swapped the arguments for `mkTidalWith` to align with previous tidal versions.  
`tidalInst <- mkTidalWith mkOscMap (setFrameTimespan (1/20) $ setProcessAhead (3/10) defaultConfig) `

also `enableLink` and `disableLink` were added and commented in the `BootTidal.hs`