### PR TITLE
Reinstate transitions

### DIFF
--- a/BootTidal.hs
+++ b/BootTidal.hs
@@ -20,27 +20,8 @@ instance Tidally where tidal = tidalInst
 -- Uncomment the next line to enable Ableton Link on startup.
 -- enableLink
 
--- You can add your own aliases in this file. Here are some examples:
--- :{
--- let xfade i = transition tidal True (Sound.Tidal.Transition.xfadeIn 4) i
---     xfadeIn i t = transition tidal True (Sound.Tidal.Transition.xfadeIn t) i
---     histpan i t = transition tidal True (Sound.Tidal.Transition.histpan t) i
---     wait i t = transition tidal True (Sound.Tidal.Transition.wait t) i
---     waitT i f t = transition tidal True (Sound.Tidal.Transition.waitT f t) i
---     jump i = transition tidal True (Sound.Tidal.Transition.jump) i
---     jumpIn i t = transition tidal True (Sound.Tidal.Transition.jumpIn t) i
---     jumpIn' i t = transition tidal True (Sound.Tidal.Transition.jumpIn' t) i
---     jumpMod i t = transition tidal True (Sound.Tidal.Transition.jumpMod t) i
---     jumpMod' i t p = transition tidal True (Sound.Tidal.Transition.jumpMod' t p) i
---     mortal i lifespan release = transition tidal True (Sound.Tidal.Transition.mortal lifespan release) i
---     interpolate i = transition tidal True (Sound.Tidal.Transition.interpolate) i
---     interpolateIn i t = transition tidal True (Sound.Tidal.Transition.interpolateIn t) i
---     clutch i = transition tidal True (Sound.Tidal.Transition.clutch) i
---     clutchIn i t = transition tidal True (Sound.Tidal.Transition.clutchIn t) i
---     anticipate i = transition tidal True (Sound.Tidal.Transition.anticipate) i
---     anticipateIn i t = transition tidal True (Sound.Tidal.Transition.anticipateIn t) i
---     forId i t = transition tidal False (Sound.Tidal.Transition.mortalOverlay t) i
--- :}
+-- You can also add your own aliases in this file. For example:
+-- fastsquizzed pat = fast 2 $ pat # squiz 1.5
 
 :set -fwarn-orphans
 :set prompt "tidal> "

--- a/BootTidal.hs
+++ b/BootTidal.hs
@@ -16,8 +16,8 @@ tidalInst <- mkTidal
 -- It has to go after you define 'tidalInst'.
 instance Tidally where tidal = tidalInst
 
--- `enableLink` and `disableLink` can be used to toggle Ableton Link.
--- Uncomment the next line to enable Ableton Link on startup.
+-- `enableLink` and `disableLink` can be used to toggle synchronisation using the Link protocol.
+-- Uncomment the next line to enable Link on startup.
 -- enableLink
 
 -- You can also add your own aliases in this file. For example:

--- a/src/Sound/Tidal/Boot.hs
+++ b/src/Sound/Tidal/Boot.hs
@@ -88,7 +88,25 @@ module Sound.Tidal.Boot
     setS,
     setR,
     setB,
+    xfade,
+    xfadeIn,
     module Sound.Tidal.Context,
+    histpan,
+    wait,
+    waitT,
+    jump,
+    jumpIn,
+    jumpIn',
+    jumpMod,
+    jumpMod',
+    mortal,
+    interpolate,
+    interpolateIn,
+    clutch,
+    clutchIn,
+    anticipate,
+    anticipateIn,
+    forId,
   )
 where
 
@@ -322,3 +340,57 @@ setR = streamSetR tidal
 -- | See 'Sound.Tidal.Stream.streamSetB'.
 setB :: (Tidally) => String -> Pattern Bool -> IO ()
 setB = streamSetB tidal
+
+xfade :: (Tidally) => ID -> ControlPattern -> IO ()
+xfade i = transition tidal True (_xfadeIn 4) i
+
+xfadeIn :: (Tidally) => ID -> Time -> ControlPattern -> IO ()
+xfadeIn i t = transition tidal True (_xfadeIn t) i
+
+histpan :: (Tidally) => ID -> Int -> ControlPattern -> IO ()
+histpan i t = transition tidal True (_histpan t) i
+
+wait :: (Tidally) => ID -> Time -> ControlPattern -> IO ()
+wait i t = transition tidal True (_wait t) i
+
+waitT :: (Tidally) => ID -> (Time -> [ControlPattern] -> ControlPattern) -> Time -> ControlPattern -> IO ()
+waitT i f t = transition tidal True (_waitT f t) i
+
+jump :: (Tidally) => ID -> ControlPattern -> IO ()
+jump i = transition tidal True _jump i
+
+jumpIn :: (Tidally) => ID -> Int -> ControlPattern -> IO ()
+jumpIn i t = transition tidal True (_jumpIn t) i
+
+jumpIn' :: (Tidally) => ID -> Int -> ControlPattern -> IO ()
+jumpIn' i t = transition tidal True (_jumpIn' t) i
+
+jumpMod :: (Tidally) => ID -> Int -> ControlPattern -> IO ()
+jumpMod i t = transition tidal True (_jumpMod t) i
+
+jumpMod' :: (Tidally) => ID -> Int -> Int -> ControlPattern -> IO ()
+jumpMod' i t pat = transition tidal True (_jumpMod' t pat) i
+
+mortal :: (Tidally) => ID -> Time -> Time -> ControlPattern -> IO ()
+mortal i lifespan releasetime = transition tidal True (_mortal lifespan releasetime) i
+
+interpolate :: (Tidally) => ID -> ControlPattern -> IO ()
+interpolate i = transition tidal True _interpolate i
+
+interpolateIn :: (Tidally) => ID -> Time -> ControlPattern -> IO ()
+interpolateIn i t = transition tidal True (_interpolateIn t) i
+
+clutch :: (Tidally) => ID -> ControlPattern -> IO ()
+clutch i = transition tidal True _clutch i
+
+clutchIn :: (Tidally) => ID -> Time -> ControlPattern -> IO ()
+clutchIn i t = transition tidal True (_clutchIn t) i
+
+anticipate :: (Tidally) => ID -> ControlPattern -> IO ()
+anticipate i = transition tidal True _anticipate i
+
+anticipateIn :: (Tidally) => ID -> Time -> ControlPattern -> IO ()
+anticipateIn i t = transition tidal True (_anticipateIn t) i
+
+forId :: (Tidally) => ID -> Time -> ControlPattern -> IO ()
+forId i t = transition tidal False (_mortalOverlay t) i

--- a/src/Sound/Tidal/Safe/Boot.hs
+++ b/src/Sound/Tidal/Safe/Boot.hs
@@ -94,39 +94,39 @@ setcps = asap . cps
 
 -- * Transitions
 
-xfade i = transition True (Sound.Tidal.Transition.xfadeIn 4) i
+xfade i = transition True (Sound.Tidal.Transition._xfadeIn 4) i
 
-xfadeIn i t = transition True (Sound.Tidal.Transition.xfadeIn t) i
+xfadeIn i t = transition True (Sound.Tidal.Transition._xfadeIn t) i
 
-histpan i t = transition True (Sound.Tidal.Transition.histpan t) i
+histpan i t = transition True (Sound.Tidal.Transition._histpan t) i
 
-wait i t = transition True (Sound.Tidal.Transition.wait t) i
+wait i t = transition True (Sound.Tidal.Transition._wait t) i
 
-waitT i f t = transition True (Sound.Tidal.Transition.waitT f t) i
+waitT i f t = transition True (Sound.Tidal.Transition._waitT f t) i
 
-jump i = transition True (Sound.Tidal.Transition.jump) i
+jump i = transition True (Sound.Tidal.Transition._jump) i
 
-jumpIn i t = transition True (Sound.Tidal.Transition.jumpIn t) i
+jumpIn i t = transition True (Sound.Tidal.Transition._jumpIn t) i
 
-jumpIn' i t = transition True (Sound.Tidal.Transition.jumpIn' t) i
+jumpIn' i t = transition True (Sound.Tidal.Transition._jumpIn' t) i
 
-jumpMod i t = transition True (Sound.Tidal.Transition.jumpMod t) i
+jumpMod i t = transition True (Sound.Tidal.Transition._jumpMod t) i
 
-mortal i lifespan releaseTime = transition True (Sound.Tidal.Transition.mortal lifespan releaseTime) i
+mortal i lifespan releaseTime = transition True (Sound.Tidal.Transition._mortal lifespan releaseTime) i
 
-interpolate i = transition True (Sound.Tidal.Transition.interpolate) i
+interpolate i = transition True (Sound.Tidal.Transition._interpolate) i
 
-interpolateIn i t = transition True (Sound.Tidal.Transition.interpolateIn t) i
+interpolateIn i t = transition True (Sound.Tidal.Transition._interpolateIn t) i
 
-clutch i = transition True (Sound.Tidal.Transition.clutch) i
+clutch i = transition True (Sound.Tidal.Transition._clutch) i
 
-clutchIn i t = transition True (Sound.Tidal.Transition.clutchIn t) i
+clutchIn i t = transition True (Sound.Tidal.Transition._clutchIn t) i
 
-anticipate i = transition True (Sound.Tidal.Transition.anticipate) i
+anticipate i = transition True (Sound.Tidal.Transition._anticipate) i
 
-anticipateIn i t = transition True (Sound.Tidal.Transition.anticipateIn t) i
+anticipateIn i t = transition True (Sound.Tidal.Transition._anticipateIn t) i
 
-forId i t = transition False (Sound.Tidal.Transition.mortalOverlay t) i
+forId i t = transition False (Sound.Tidal.Transition._mortalOverlay t) i
 
 d1 = p 1 . (|< orbit 0)
 

--- a/src/Sound/Tidal/Transition.hs
+++ b/src/Sound/Tidal/Transition.hs
@@ -7,13 +7,16 @@ import qualified Data.Map.Strict as Map
 -- import Data.Maybe (fromJust)
 
 import qualified Sound.Tidal.Clock as Clock
-import Sound.Tidal.Control
+import Sound.Tidal.Control (_stut)
 import Sound.Tidal.Core
-import Sound.Tidal.ID
+import Sound.Tidal.ID (ID (fromID))
 import Sound.Tidal.Params (gain, pan)
 import Sound.Tidal.Pattern
-import Sound.Tidal.Stream.Config
+import Sound.Tidal.Stream.Config (Config (cClockConfig))
 import Sound.Tidal.Stream.Types
+  ( PlayState (PlayState, psHistory, psMute, psPattern, psSolo),
+    Stream (sClockRef, sConfig, sPMapMV),
+  )
 -- import Sound.Tidal.Tempo as T
 import Sound.Tidal.UI (fadeInFrom, fadeOutFrom)
 import Sound.Tidal.Utils (enumerate)
@@ -44,13 +47,13 @@ type TransitionMapper = Time -> [ControlPattern] -> ControlPattern
 transition :: Stream -> Bool -> TransitionMapper -> ID -> ControlPattern -> IO ()
 transition stream historyFlag mapper patId !pat = do
   let appendPat flag = if flag then (pat :) else id
-      updatePS (Just playState) = playState {psHistory = (appendPat historyFlag) (psHistory playState)}
+      updatePS (Just playState) = playState {psHistory = appendPat historyFlag (psHistory playState)}
       updatePS Nothing =
         PlayState
           { psPattern = silence,
             psMute = False,
             psSolo = False,
-            psHistory = (appendPat historyFlag) (silence : [])
+            psHistory = appendPat historyFlag [silence]
           }
       transition' pat' = do
         t <- Clock.getCycleTime (cClockConfig $ sConfig stream) (sClockRef stream)
@@ -62,9 +65,9 @@ transition stream historyFlag mapper patId !pat = do
   _ <- swapMVar (sPMapMV stream) pMap'
   return ()
 
-mortalOverlay :: Time -> Time -> [Pattern a] -> Pattern a
-mortalOverlay _ _ [] = silence
-mortalOverlay t now (pat : ps) = overlay (pop ps) (playFor s (s + t) pat)
+_mortalOverlay :: Time -> Time -> [Pattern a] -> Pattern a
+_mortalOverlay _ _ [] = silence
+_mortalOverlay t now (pat : ps) = overlay (pop ps) (playFor s (s + t) pat)
   where
     pop [] = silence
     pop (x : _) = x
@@ -73,40 +76,40 @@ mortalOverlay t now (pat : ps) = overlay (pop ps) (playFor s (s + t) pat)
 -- | Washes away the current pattern after a certain delay by applying a
 --    function to it over time, then switching over to the next pattern to
 --    which another function is applied.
-wash :: (Pattern a -> Pattern a) -> (Pattern a -> Pattern a) -> Time -> Time -> Time -> Time -> [Pattern a] -> Pattern a
-wash _ _ _ _ _ _ [] = silence
-wash _ _ _ _ _ _ (pat : []) = pat
-wash fout fin delay durin durout now (pat : pat' : _) =
+_wash :: (Pattern a -> Pattern a) -> (Pattern a -> Pattern a) -> Time -> Time -> Time -> Time -> [Pattern a] -> Pattern a
+_wash _ _ _ _ _ _ [] = silence
+_wash _ _ _ _ _ _ [pat] = pat
+_wash fout fin delay durin durout now (pat : pat' : _) =
   stack
-    [ (filterWhen (< (now + delay)) pat'),
-      (filterWhen (between (now + delay) (now + delay + durin)) $ fout pat'),
-      (filterWhen (between (now + delay + durin) (now + delay + durin + durout)) $ fin pat),
-      (filterWhen (>= (now + delay + durin + durout)) $ pat)
+    [ filterWhen (< (now + delay)) pat',
+      filterWhen (between (now + delay) (now + delay + durin)) $ fout pat',
+      filterWhen (between (now + delay + durin) (now + delay + durin + durout)) $ fin pat,
+      filterWhen (>= (now + delay + durin + durout)) pat
     ]
   where
     between lo hi x = (x >= lo) && (x < hi)
 
-washIn :: (Pattern a -> Pattern a) -> Time -> Time -> [Pattern a] -> Pattern a
-washIn f durin now pats = wash f id 0 durin 0 now pats
+_washIn :: (Pattern a -> Pattern a) -> Time -> Time -> [Pattern a] -> Pattern a
+_washIn f durin now pats = _wash f id 0 durin 0 now pats
 
-xfadeIn :: Time -> Time -> [ControlPattern] -> ControlPattern
-xfadeIn _ _ [] = silence
-xfadeIn _ _ (pat : []) = pat
-xfadeIn t now (pat : pat' : _) = overlay (pat |* gain (now `rotR` (_slow t envEqR))) (pat' |* gain (now `rotR` (_slow t (envEq))))
+_xfadeIn :: Time -> Time -> [ControlPattern] -> ControlPattern
+_xfadeIn _ _ [] = silence
+_xfadeIn _ _ [pat] = pat
+_xfadeIn t now (pat : pat' : _) = overlay (pat |* gain (now `rotR` _slow t envEqR)) (pat' |* gain (now `rotR` _slow t envEq))
 
 -- | Pans the last n versions of the pattern across the field
-histpan :: Int -> Time -> [ControlPattern] -> ControlPattern
-histpan _ _ [] = silence
-histpan 0 _ _ = silence
-histpan n _ ps = stack $ map (\(i, pat) -> pat # pan (pure $ (fromIntegral i) / (fromIntegral n'))) (enumerate ps')
+_histpan :: Int -> Time -> [ControlPattern] -> ControlPattern
+_histpan _ _ [] = silence
+_histpan 0 _ _ = silence
+_histpan n _ ps = stack $ map (\(i, pat) -> pat # pan (pure $ fromIntegral i / fromIntegral n')) (enumerate ps')
   where
     ps' = take n ps
     n' = length ps' -- in case there's fewer patterns than requested
 
 -- | Just stop for a bit before playing new pattern
-wait :: Time -> Time -> [ControlPattern] -> ControlPattern
-wait _ _ [] = silence
-wait t now (pat : _) = filterWhen (>= (nextSam (now + t - 1))) pat
+_wait :: Time -> Time -> [ControlPattern] -> ControlPattern
+_wait _ _ [] = silence
+_wait t now (pat : _) = filterWhen (>= nextSam (now + t - 1)) pat
 
 -- | Just as `wait`, `waitT` stops for a bit and then applies the given transition to the playing pattern
 --
@@ -115,61 +118,59 @@ wait t now (pat : _) = filterWhen (>= (nextSam (now + t - 1))) pat
 --
 -- t1 (waitT (xfadeIn 8) 4) $ sound "hh*8"
 -- @
-waitT :: (Time -> [ControlPattern] -> ControlPattern) -> Time -> Time -> [ControlPattern] -> ControlPattern
-waitT _ _ _ [] = silence
-waitT f t now pats = filterWhen (>= (nextSam (now + t - 1))) (f (now + t) pats)
+_waitT :: (Time -> [ControlPattern] -> ControlPattern) -> Time -> Time -> [ControlPattern] -> ControlPattern
+_waitT _ _ _ [] = silence
+_waitT f t now pats = filterWhen (>= nextSam (now + t - 1)) (f (now + t) pats)
 
 -- |
 -- Jumps directly into the given pattern, this is essentially the _no transition_-transition.
 --
 -- Variants of @jump@ provide more useful capabilities, see @jumpIn@ and @jumpMod@
-jump :: Time -> [ControlPattern] -> ControlPattern
-jump = jumpIn 0
+_jump :: Time -> [ControlPattern] -> ControlPattern
+_jump = _jumpIn 0
 
 -- | Sharp `jump` transition after the specified number of cycles have passed.
 --
 -- @
 -- t1 (jumpIn 2) $ sound "kick(3,8)"
 -- @
-jumpIn :: Int -> Time -> [ControlPattern] -> ControlPattern
-jumpIn n = wash id id (fromIntegral n) 0 0
+_jumpIn :: Int -> Time -> [ControlPattern] -> ControlPattern
+_jumpIn n = _wash id id (fromIntegral n) 0 0
 
 -- | Unlike `jumpIn` the variant `jumpIn'` will only transition at cycle boundary (e.g. when the cycle count is an integer).
-jumpIn' :: Int -> Time -> [ControlPattern] -> ControlPattern
-jumpIn' n now = wash id id ((nextSam now) - now + (fromIntegral n)) 0 0 now
+_jumpIn' :: Int -> Time -> [ControlPattern] -> ControlPattern
+_jumpIn' n now = _wash id id (nextSam now - now + fromIntegral n) 0 0 now
 
 -- | Sharp `jump` transition at next cycle boundary where cycle mod n == 0
-jumpMod :: Int -> Time -> [ControlPattern] -> ControlPattern
-jumpMod n now = jumpIn' ((n - 1) - ((floor now) `mod` n)) now
+_jumpMod :: Int -> Time -> [ControlPattern] -> ControlPattern
+_jumpMod n now = _jumpIn' ((n - 1) - (floor now `mod` n)) now
 
 -- | Sharp `jump` transition at next cycle boundary where cycle mod n == p
-jumpMod' :: Int -> Int -> Time -> [ControlPattern] -> ControlPattern
-jumpMod' n p now = Sound.Tidal.Transition.jumpIn' ((n - 1) - ((floor now) `mod` n) + p) now
+_jumpMod' :: Int -> Int -> Time -> [ControlPattern] -> ControlPattern
+_jumpMod' n p now = _jumpIn' ((n - 1) - (floor now `mod` n) + p) now
 
 -- | Degrade the new pattern over time until it ends in silence
-mortal :: Time -> Time -> Time -> [ControlPattern] -> ControlPattern
-mortal _ _ _ [] = silence
-mortal lifespan release now (p : _) = overlay (filterWhen (< (now + lifespan)) p) (filterWhen (>= (now + lifespan)) (fadeOutFrom (now + lifespan) release p))
+_mortal :: Time -> Time -> Time -> [ControlPattern] -> ControlPattern
+_mortal _ _ _ [] = silence
+_mortal lifespan release now (p : _) = overlay (filterWhen (< (now + lifespan)) p) (filterWhen (>= (now + lifespan)) (fadeOutFrom (now + lifespan) release p))
 
-interpolate :: Time -> [ControlPattern] -> ControlPattern
-interpolate = interpolateIn 4
+_interpolate :: Time -> [ControlPattern] -> ControlPattern
+_interpolate = _interpolateIn 4
 
-interpolateIn :: Time -> Time -> [ControlPattern] -> ControlPattern
-interpolateIn _ _ [] = silence
-interpolateIn _ _ (p : []) = p
-interpolateIn t now (pat : pat' : _) = f <$> pat' *> pat <* automation
+_interpolateIn :: Time -> Time -> [ControlPattern] -> ControlPattern
+_interpolateIn _ _ [] = silence
+_interpolateIn _ _ [p] = p
+_interpolateIn t now (pat : pat' : _) = f <$> pat' *> pat <* automation
   where
-    automation = now `rotR` (_slow t envL)
-    f =
-      ( \a b x ->
-          Map.unionWith
-            ( fNum2
-                (\a' b' -> floor $ (fromIntegral a') * x + (fromIntegral b') * (1 - x))
-                (\a' b' -> a' * x + b' * (1 - x))
-            )
-            b
-            a
-      )
+    automation = now `rotR` _slow t envL
+    f a b x =
+      Map.unionWith
+        ( fNum2
+            (\a' b' -> floor $ fromIntegral a' * x + fromIntegral b' * (1 - x))
+            (\a' b' -> a' * x + b' * (1 - x))
+        )
+        b
+        a
 
 -- |
 -- Degrades the current pattern while undegrading the next.
@@ -183,8 +184,8 @@ interpolateIn t now (pat : pat' : _) = f <$> pat' *> pat <* automation
 -- @
 --
 -- @clutch@ takes two cycles for the transition, essentially this is @clutchIn 2@.
-clutch :: Time -> [Pattern a] -> Pattern a
-clutch = clutchIn 2
+_clutch :: Time -> [Pattern a] -> Pattern a
+_clutch = _clutchIn 2
 
 -- |
 -- Also degrades the current pattern and undegrades the next.
@@ -197,10 +198,10 @@ clutch = clutchIn 2
 -- @
 --
 -- will take 8 cycles for the transition.
-clutchIn :: Time -> Time -> [Pattern a] -> Pattern a
-clutchIn _ _ [] = silence
-clutchIn _ _ (p : []) = p
-clutchIn t now (p : p' : _) = overlay (fadeOutFrom now t p') (fadeInFrom now t p)
+_clutchIn :: Time -> Time -> [Pattern a] -> Pattern a
+_clutchIn _ _ [] = silence
+_clutchIn _ _ [p] = p
+_clutchIn t now (p : p' : _) = overlay (fadeOutFrom now t p') (fadeInFrom now t p)
 
 -- | same as `anticipate` though it allows you to specify the number of cycles until dropping to the new pattern, e.g.:
 --
@@ -209,13 +210,13 @@ clutchIn t now (p : p' : _) = overlay (fadeOutFrom now t p') (fadeInFrom now t p
 --
 -- t1 (anticipateIn 4) $ sound "jvbass(5,8)"
 -- @
-anticipateIn :: Time -> Time -> [ControlPattern] -> ControlPattern
-anticipateIn t now pats = washIn (innerJoin . (\pat -> (\v -> _stut 8 0.2 v pat) <$> (now `rotR` (_slow t $ toRational <$> envLR)))) t now pats
+_anticipateIn :: Time -> Time -> [ControlPattern] -> ControlPattern
+_anticipateIn t now pats = _washIn (innerJoin . (\pat -> (\v -> _stut 8 0.2 v pat) <$> (now `rotR` _slow t (toRational <$> envLR)))) t now pats
 
 -- wash :: (Pattern a -> Pattern a) -> (Pattern a -> Pattern a) -> Time -> Time -> Time -> Time -> [Pattern a] -> Pattern a
 
 -- | `anticipate` is an increasing comb filter.
 --
 -- Build up some tension, culminating in a _drop_ to the new pattern after 8 cycles.
-anticipate :: Time -> [ControlPattern] -> ControlPattern
-anticipate = anticipateIn 8
+_anticipate :: Time -> [ControlPattern] -> ControlPattern
+_anticipate = _anticipateIn 8

--- a/tidal-core/src/Sound/Tidal/UI.hs
+++ b/tidal-core/src/Sound/Tidal/UI.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -39,7 +38,6 @@ import Data.Fixed (mod')
 import qualified Data.IntMap.Strict as IM
 import Data.List
   ( elemIndex,
-    findIndex,
     findIndices,
     groupBy,
     intercalate,
@@ -1432,13 +1430,13 @@ lindenmayerI n r s = fmap (fromIntegral . digitToInt) $ lindenmayer n r s
 runMarkov :: Int -> [[Double]] -> Int -> Time -> [Int]
 runMarkov n tp xi seed = take n $ map fst $ L.iterate' (markovStep $ renorm) (xi, seed + delta)
   where
-    markovStep tp' (x, seed) = (let v = tp' IM.! x in findIndex (r * fst (Map.findMax v)) v, seed + delta)
+    markovStep tp' (x, seed') = (let v = tp' IM.! x in findIndex (r * fst (Map.findMax v)) v, seed' + delta)
       where
-        r = timeToRand $ seed
+        r = timeToRand seed'
     renorm :: IM.IntMap (Map.Map Double Int)
     renorm = IM.fromList $ zip [0 ..] [Map.fromList $ zip (tail $ scanl (+) 0 x) [0 ..] | x <- tp]
     findIndex :: Double -> Map.Map Double Int -> Int
-    findIndex x v = fromMaybe 0 $ fmap snd $ Map.lookupGE x v
+    findIndex x v = maybe 0 snd (Map.lookupGE x v)
     delta = 1 / fromIntegral n
 
 -- | @markovPat n xi tp@ generates a one-cycle pattern of @n@ steps in a Markov
@@ -1567,7 +1565,7 @@ fit' cyc n from to p = squeezeJoin $ _fit n mapMasks to
   where
     mapMasks =
       [ stretch $ mask (const True <$> filterValues (== i) from') p'
-      | i <- [0 .. n - 1]
+        | i <- [0 .. n - 1]
       ]
     p' = density cyc p
     from' = density cyc from
@@ -2437,7 +2435,7 @@ cross f p p' = pattern $ \t -> concat [filter flt $ arc p t,
 -- > d1 $ jux (iter 4) $ sound "arpy arpy:2*2"
 -- >   |+ speed (slow 4 $ sine1 * 0.5 + 1)
 range :: (Num a) => Pattern a -> Pattern a -> Pattern a -> Pattern a
-range fromP toP p = (\from to v -> ((v * (to - from)) + from)) <$> fromP *> toP *> p
+range fromP toP p = (\from to v -> (v * (to - from)) + from) <$> fromP *> toP *> p
 
 _range :: (Functor f, Num b) => b -> b -> f b -> f b
 _range from to p = (+ from) . (* (to - from)) <$> p
@@ -2900,7 +2898,7 @@ squeezeJoinUp pp = pp {query = q, pureValue = Nothing}
 _chew :: Int -> Pattern Int -> ControlPattern -> ControlPattern
 _chew n ipat pat = squeezeJoinUp (zoomslice <$> ipat) |/ P.speed (pure $ fromIntegral n)
   where
-    zoomslice i = zoom (i' / (fromIntegral n), (i' + 1) / (fromIntegral n)) (pat)
+    zoomslice i = zoom (i' / fromIntegral n, (i' + 1) / fromIntegral n) pat
       where
         i' = fromIntegral $ i `mod` n
 


### PR DESCRIPTION
Prefix the internal functions with `_` to avoid name clash
Move the transition UI from commented out section in BootTidal.hs to Sound.Tidal.Boot
Create another example of a custom alias