### PR TITLE
Corrects the scaleWithList function

### DIFF
--- a/src/Sound/Tidal/Scales.hs
+++ b/src/Sound/Tidal/Scales.hs
@@ -255,7 +255,19 @@ scaleWith = getScaleMod scaleTable
 {- Variant of @scaleWith@ providing a list of modifier functions instead of a single function
 -}
 scaleWithList :: (Eq a, Fractional a) => Pattern String -> ([[a] -> [a]]) -> Pattern Int -> Pattern a
-scaleWithList sp fs p = slowcat $ map (\f -> scaleWith sp f p) fs
+scaleWithList _ [] _ = silence
+scaleWithList sp (f : []) p = scaleWith sp f p
+scaleWithList sp fs p = Pattern q
+  where
+    n = length fs
+    q st = concatMap (ff st)
+      $ arcCyclesZW (arc st)
+    ff st a = query pp $ st {arc = a}
+      where
+        f = fs !! i
+        cyc = (floor $ start a) :: Int
+        i = cyc `mod` n
+        pp = (scaleWith sp f p)
 
 {- Variant of @getScale@ used to build the @scaleWith@ function
 -}


### PR DESCRIPTION
It now behaves in a more intuitive way, with the cycles underlying the functions list synchronizing with the pattern's cycles instead of duplicating them. Implementation inspired by that of `cat`.