### PR TITLE
Corrects the scaleWithList function 

### DIFF
--- a/tidal-core/src/Sound/Tidal/Scales.hs
+++ b/tidal-core/src/Sound/Tidal/Scales.hs
@@ -332,8 +332,9 @@ scaleWithList sp (f : []) p = scaleMod sp f p
 scaleWithList sp fs p = Pattern q
   where
     n = length fs
-    q st = concatMap (ff st)
-      $ arcCyclesZW (arc st)
+    q st =
+      concatMap (ff st) $
+        arcCyclesZW (arc st)
     ff st a = query pp $ st {arc = a}
       where
         f = fs !! i

--- a/tidal-core/src/Sound/Tidal/Scales.hs
+++ b/tidal-core/src/Sound/Tidal/Scales.hs
@@ -322,13 +322,13 @@ These are equivalent:
 
 -}
 scaleWith :: (Eq a, Fractional a) => Pattern String -> ([a] -> [a]) -> Pattern Int -> Pattern a
-scaleWith = getScaleMod scaleTable
+scaleWith = getScaleWith scaleTable
 
 {- Variant of @scaleWith@ providing a list of modifier functions instead of a single function
 -}
 scaleWithList :: (Eq a, Fractional a) => Pattern String -> ([[a] -> [a]]) -> Pattern Int -> Pattern a
 scaleWithList _ [] _ = silence
-scaleWithList sp (f : []) p = scaleMod sp f p
+scaleWithList sp (f : []) p = scaleWith sp f p
 scaleWithList sp fs p = Pattern q
   where
     n = length fs
@@ -340,12 +340,12 @@ scaleWithList sp fs p = Pattern q
         f = fs !! i
         cyc = (floor $ start a) :: Int
         i = cyc `mod` n
-        pp = (scaleMod sp f p)
+        pp = (scaleWith sp f p)
 
 {- Variant of @getScale@ used to build the @scaleWith@ function
 -}
-getScaleMod :: (Eq a, Fractional a) => [(String, [a])] -> Pattern String -> ([a] -> [a]) -> Pattern Int -> Pattern a
-getScaleMod table sp f p =
+getScaleWith :: (Eq a, Fractional a) => [(String, [a])] -> Pattern String -> ([a] -> [a]) -> Pattern Int -> Pattern a
+getScaleWith table sp f p =
   ( \n scaleName ->
       noteInScale (uniq $ f $ fromMaybe [0] $ lookup scaleName table) n
   )

--- a/tidal-core/src/Sound/Tidal/Scales.hs
+++ b/tidal-core/src/Sound/Tidal/Scales.hs
@@ -20,7 +20,7 @@ module Sound.Tidal.Scales (scale, scaleList, scaleTable, getScale, scaleWith, sc
 
 import Data.Maybe (fromMaybe)
 import Sound.Tidal.Core (slowcat)
-import Sound.Tidal.Pattern (Pattern, (<*))
+import Sound.Tidal.Pattern (Pattern, (<*), arc)
 import Sound.Tidal.Utils ((!!!))
 import Prelude hiding ((*>), (<*))
 

--- a/tidal-core/src/Sound/Tidal/Scales.hs
+++ b/tidal-core/src/Sound/Tidal/Scales.hs
@@ -327,7 +327,19 @@ scaleWith = getScaleMod scaleTable
 {- Variant of @scaleWith@ providing a list of modifier functions instead of a single function
 -}
 scaleWithList :: (Eq a, Fractional a) => Pattern String -> ([[a] -> [a]]) -> Pattern Int -> Pattern a
-scaleWithList sp fs p = slowcat $ map (\f -> scaleWith sp f p) fs
+scaleWithList _ [] _ = silence
+scaleWithList sp (f : []) p = scaleMod sp f p
+scaleWithList sp fs p = Pattern q
+  where
+    n = length fs
+    q st = concatMap (ff st)
+      $ arcCyclesZW (arc st)
+    ff st a = query pp $ st {arc = a}
+      where
+        f = fs !! i
+        cyc = (floor $ start a) :: Int
+        i = cyc `mod` n
+        pp = (scaleMod sp f p)
 
 {- Variant of @getScale@ used to build the @scaleWith@ function
 -}

--- a/tidal-core/src/Sound/Tidal/Scales.hs
+++ b/tidal-core/src/Sound/Tidal/Scales.hs
@@ -20,7 +20,7 @@ module Sound.Tidal.Scales (scale, scaleList, scaleTable, getScale, scaleWith, sc
 
 import Data.Maybe (fromMaybe)
 import Sound.Tidal.Core (slowcat)
-import Sound.Tidal.Pattern (Pattern, (<*), arc)
+import Sound.Tidal.Pattern (Pattern, arc, (<*))
 import Sound.Tidal.Utils ((!!!))
 import Prelude hiding ((*>), (<*))
 


### PR DESCRIPTION
It now behaves in a more intuitive way, with the cycles underlying the functions list synchronizing with the pattern's cycles instead of duplicating them. Implementation inspired by that of `cat`.

(sorry for the duplicate pull request, I forgot to merge the main branch before adding my contributions)