### PR TITLE
fix for plyWith: tweak type defaults, turn off related warning

### DIFF
--- a/BootTidal.hs
+++ b/BootTidal.hs
@@ -6,11 +6,13 @@
 -- Import all the boot functions and aliases.
 import Sound.Tidal.Boot
 
-default (Pattern String, Integer, Double)
+default (Rational, Integer, Double, Pattern String)
 
 -- Create a Tidal Stream with the default settings.
 -- Use 'mkTidalWith' to customize these settings.
 tidalInst <- mkTidal
+
+-- tidalInst <- mkTidalWith [(superdirtTarget { oLatency = 0.01 }, [superdirtShape])] (setFrameTimespan (1/50) $ setProcessAhead (1/20) defaultConfig)
 
 -- This orphan instance makes the boot aliases work!
 -- It has to go after you define 'tidalInst'.
@@ -23,6 +25,6 @@ instance Tidally where tidal = tidalInst
 -- You can also add your own aliases in this file. For example:
 -- fastsquizzed pat = fast 2 $ pat # squiz 1.5
 
-:set -fwarn-orphans
+:set -fwarn-orphans -Wno-type-defaults
 :set prompt "tidal> "
 :set prompt-cont ""


### PR DESCRIPTION
Needed for recent versions of `ghc`