### PR TITLE
import IsString from a portable module

### DIFF
--- a/tidal-core/src/Sound/Tidal/ParseBP.hs
+++ b/tidal-core/src/Sound/Tidal/ParseBP.hs
@@ -39,8 +39,8 @@ import Data.Functor.Identity (Identity)
 import Data.List (intercalate)
 import Data.Maybe (fromMaybe)
 import Data.Ratio ((%))
+import Data.String (IsString (..))
 import Data.Typeable (Typeable)
-import GHC.Exts (IsString (..))
 import Sound.Tidal.Chords
   ( Modifier (..),
     chordTable,

--- a/tidal-core/src/Sound/Tidal/Simple.hs
+++ b/tidal-core/src/Sound/Tidal/Simple.hs
@@ -21,7 +21,7 @@
 
 module Sound.Tidal.Simple where
 
-import GHC.Exts (IsString (..))
+import Data.String (IsString (..))
 import Sound.Tidal.Control (chop, hurry)
 import Sound.Tidal.Core ((#), (<~), (|*))
 import Sound.Tidal.Params (crush, gain, pan, s, speed)


### PR DESCRIPTION
`GHC.Exts` is GHC-only, `Data.String` works with other compilers too (like MicroHs)